### PR TITLE
fix solver stats extraction and add tests

### DIFF
--- a/cvxpygen/utils.py
+++ b/cvxpygen/utils.py
@@ -1704,7 +1704,7 @@ def write_method(f, configuration, variable_info, dual_variable_info, parameter_
     f.write('    results_dict = {\'solver_specific_stats\': solver_specific_stats,\n')
     f.write('                    \'num_iters\': res.cpg_info.iter,\n')
     f.write('                    \'solve_time\': t1 - t0}\n')
-    f.write(f'    prob._solver_stats = SolverStats(results_dict, \'{configuration.solver_name}\')\n\n')
+    f.write(f'    prob._solver_stats = SolverStats.from_dict(results_dict, \'{configuration.solver_name}\')\n\n')
     f.write(f'    return prob.value{", res.cpg_info.gradient_primal, res.cpg_info.gradient_dual" if configuration.gradient else ""}\n\n\n')
     
     if configuration.gradient:

--- a/tests/test_E2E_LP.py
+++ b/tests/test_E2E_LP.py
@@ -130,7 +130,7 @@ def test(name, solver, style, seed):
 
     prob = assign_data(prob, name, seed)
 
-    val_py, prim_py, dual_py, val_cg, prim_cg, dual_cg, prim_py_norm, dual_py_norm = \
+    val_py, prim_py, dual_py, val_cg, prim_cg, dual_cg, prim_py_norm, dual_py_norm, stats_py, stats_cg, sol_cg = \
         utils_test.check(prob, solver, name, get_primal_vec)
 
     if not np.isinf(val_py):
@@ -146,6 +146,8 @@ def test(name, solver, style, seed):
     else:
         assert np.linalg.norm(dual_cg, 2) < 1e-3
 
+    assert stats_py.solver_name == stats_cg.solver_name
+    assert sol_cg.opt_val == val_cg
 
 def test_clarabel():
     test('network', 'CLARABEL', 'loops', 0)

--- a/tests/test_E2E_QP.py
+++ b/tests/test_E2E_QP.py
@@ -210,7 +210,7 @@ def test(name, solver, style, seed):
 
     prob = assign_data(prob, name, seed)
 
-    val_py, prim_py, dual_py, val_cg, prim_cg, dual_cg, prim_py_norm, dual_py_norm = \
+    val_py, prim_py, dual_py, val_cg, prim_cg, dual_cg, prim_py_norm, dual_py_norm, stats_py, stats_cg, sol_cg = \
         utils_test.check(prob, solver, name, get_primal_vec)
 
     if not np.isinf(val_py):
@@ -225,6 +225,9 @@ def test(name, solver, style, seed):
         assert np.linalg.norm(dual_cg - dual_py, 2) / dual_py_norm < 0.1
     else:
         assert np.linalg.norm(dual_cg, 2) < 1e-3
+        
+    assert stats_py.solver_name == stats_cg.solver_name
+    assert sol_cg.opt_val == val_cg
 
     
 def test_OSQP_verbose():

--- a/tests/test_E2E_SOCP.py
+++ b/tests/test_E2E_SOCP.py
@@ -105,7 +105,7 @@ def test(name, solver, style, seed):
 
     prob = assign_data(prob, name, seed)
 
-    val_py, prim_py, dual_py, val_cg, prim_cg, dual_cg, prim_py_norm, dual_py_norm = \
+    val_py, prim_py, dual_py, val_cg, prim_cg, dual_cg, prim_py_norm, dual_py_norm, stats_py, stats_cg, sol_cg = \
         utils_test.check(prob, solver, name, get_primal_vec)
 
     if not np.isinf(val_py):
@@ -120,6 +120,9 @@ def test(name, solver, style, seed):
         assert np.linalg.norm(dual_cg - dual_py, 2) / dual_py_norm < 0.1
     else:
         assert np.linalg.norm(dual_cg, 2) < 1e-3
+        
+    assert stats_py.solver_name == stats_cg.solver_name
+    assert sol_cg.opt_val == val_cg
 
 
 def test_clarabel():

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -32,6 +32,7 @@ def check(prob, solver, name, func_get_primal_vec, **extra_settings):
         val_py = prob.solve(solver=solver, **extra_settings)
     prim_py = func_get_primal_vec(prob, name)
     dual_py = get_dual_vec(prob)
+    stats_py = prob.solver_stats
     if solver == 'OSQP':
         val_cg = prob.solve(method='CPG', warm_start=False, **extra_settings)
     elif solver == 'SCS':
@@ -42,7 +43,9 @@ def check(prob, solver, name, func_get_primal_vec, **extra_settings):
         val_cg = prob.solve(method='CPG', **extra_settings)
     prim_cg = func_get_primal_vec(prob, name)
     dual_cg = get_dual_vec(prob)
+    stats_cg = prob.solver_stats
+    sol_cg = prob.solution
     prim_py_norm = np.linalg.norm(prim_py, 2)
     dual_py_norm = np.linalg.norm(dual_py, 2)
 
-    return nan_to_inf(val_py), prim_py, dual_py, nan_to_inf(val_cg), prim_cg, dual_cg, prim_py_norm, dual_py_norm
+    return nan_to_inf(val_py), prim_py, dual_py, nan_to_inf(val_cg), prim_cg, dual_cg, prim_py_norm, dual_py_norm, stats_py, stats_cg, sol_cg


### PR DESCRIPTION
Use the `from_dict` method of the `SolverStats` data class to recover solver statistics.