### PR TITLE
remove upper bound on numpy version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,21 +39,21 @@ jobs:
       run: |
         sudo apt install libeigen3-dev
         python setup.py install
-        pip install cvxpylayers torch jax
+        pip install cvxpylayers torch==2.3 jax
 
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
       run: |
         brew install eigen
         python setup.py install
-        pip install cvxpylayers torch jax
+        pip install cvxpylayers torch==2.3 jax
 
     - name: Install dependencies (Windows)
       if: runner.os == 'Windows'
       run: |
         vcpkg install eigen3:x64-windows
         python setup.py install
-        pip install cvxpylayers torch jax
+        pip install cvxpylayers torch==2.3 jax
 
     - name: Test with pytest (Linux)
       if: runner.os == 'Linux'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-13, windows-latest ]
 
     steps:
     - name: Checkout repository and submodules

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,7 +52,6 @@ jobs:
       run: |
         vcpkg install eigen3:x64-windows
         python setup.py install
-        pip install cvxpylayers torch==2.3 jax
 
     - name: Test with pytest (Linux)
       if: runner.os == 'Linux'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,21 +39,21 @@ jobs:
       run: |
         sudo apt install libeigen3-dev
         python setup.py install
-        pip install cvxpylayers torch==2.3 jax
+        pip install cvxpylayers torch==2.2 jax
 
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
       run: |
         brew install eigen
         python setup.py install
-        pip install cvxpylayers torch==2.3 jax
+        pip install cvxpylayers torch==2.2 jax
 
     - name: Install dependencies (Windows)
       if: runner.os == 'Windows'
       run: |
         vcpkg install eigen3:x64-windows
         python setup.py install
-        pip install cvxpylayers torch==2.3 jax
+        pip install cvxpylayers torch==2.2 jax
 
     - name: Test with pytest (Linux)
       if: runner.os == 'Linux'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
     - name: Checkout repository and submodules
@@ -39,21 +39,21 @@ jobs:
       run: |
         sudo apt install libeigen3-dev
         python setup.py install
-        pip install cvxpylayers torch==2.2 jax
+        pip install cvxpylayers torch==2.3 jax
 
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
       run: |
         brew install eigen
         python setup.py install
-        pip install cvxpylayers torch==2.2 jax
+        pip install cvxpylayers torch==2.3 jax
 
     - name: Install dependencies (Windows)
       if: runner.os == 'Windows'
       run: |
         vcpkg install eigen3:x64-windows
         python setup.py install
-        pip install cvxpylayers torch==2.2 jax
+        pip install cvxpylayers torch==2.3 jax
 
     - name: Test with pytest (Linux)
       if: runner.os == 'Linux'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
     - name: Checkout repository and submodules
@@ -46,7 +46,6 @@ jobs:
       run: |
         brew install eigen
         python setup.py install
-        pip install cvxpylayers torch==2.3 jax
 
     - name: Install dependencies (Windows)
       if: runner.os == 'Windows'
@@ -67,7 +66,7 @@ jobs:
       run: |
         pip install pytest
         cd tests
-        python -m pytest
+        python -m pytest test_E2E_LP.py test_E2E_QP.py test_E2E_SOCP.py
 
     - name: Test with pytest (Windows)
       if: runner.os == 'Windows'

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'ecos >= 2.0.14',
         'clarabel >= 0.6.0',
         'scipy >= 1.13.1',
-        'numpy >= 1.26.0, < 2.0',
+        'numpy >= 1.26.0',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Removes `numpy < 2.0` requirement (originally for compatibility with `torch < 2.3`). Instead, user is responsible for installing `torch >= 2.3` if they use `numpy >= 2.0`.