### PR TITLE
Rename QOCO->QOCOGEN

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,4 +72,4 @@ jobs:
       run: |
         pip install pytest
         cd tests
-        python -m pytest test_E2E_LP.py::test test_E2E_QP.py::test test_E2E_QP.py::test_OSQP_verbose test_E2E_SOCP.py::test test_E2E_LP.py::test_qoco test_unsupported_solvers.py
+        python -m pytest test_E2E_LP.py::test test_E2E_QP.py::test test_E2E_QP.py::test_OSQP_verbose test_E2E_SOCP.py::test test_E2E_LP.py::test_qocogen test_unsupported_solvers.py

--- a/cvxpygen/cpg.py
+++ b/cvxpygen/cpg.py
@@ -87,7 +87,18 @@ def extract_canonicalization(problem, solver, solver_opts, enable_settings) -> C
     interface_class, cvxpy_interface_class = get_interface_class(solver)
     
     # problem data
-    data, _, inverse_data = problem.get_problem_data(
+
+    # QOCOGEN has an identical interface to QOCO, but only QOCO is in cvxpy.
+    if solver == 'QOCOGEN':
+        data, _, inverse_data = problem.get_problem_data(
+            solver='QOCO',
+            gp=False,
+            enforce_dpp=True,
+            verbose=False,
+            solver_opts=solver_opts
+        )
+    else:
+        data, _, inverse_data = problem.get_problem_data(
         solver=solver,
         gp=False,
         enforce_dpp=True,

--- a/cvxpygen/solvers.py
+++ b/cvxpygen/solvers.py
@@ -32,7 +32,7 @@ def get_interface_class(solver_name: str) -> "SolverInterface":
         'SCS': (SCSInterface, SCS),
         'ECOS': (ECOSInterface, ECOS),
         'CLARABEL': (ClarabelInterface, CLARABEL),
-        'QOCO': (QOCOGENInterface, QOCO),
+        'QOCOGEN': (QOCOGENInterface, QOCO),
     }
     interface = mapping.get(solver_name.upper(), None)
     if interface is None:
@@ -1539,7 +1539,7 @@ class QOCOGENInterface(SolverInterface):
     def check_unsupported_cones(cone_dims: "ConeDims") -> None:
         if cone_dims.exp > 0:
             raise ValueError(
-                'Code generation with ECOS and exponential cones is not supported yet.')
+                'Exponential cones is not supported for QOCOGEN.')
 
     @staticmethod
     def ret_prim_func_exists(variable_info: PrimalVariableInfo) -> bool:

--- a/tests/test_E2E_LP.py
+++ b/tests/test_E2E_LP.py
@@ -146,7 +146,9 @@ def test(name, solver, style, seed):
     else:
         assert np.linalg.norm(dual_cg, 2) < 1e-3
 
-    assert stats_py.solver_name == stats_cg.solver_name
+    # QOCOGEN is not in CVXPY, but QOCO is an identical (but non-customized) solver, so to check QOCOGEN, we use QOCO.
+    if stats_cg.solver_name != 'QOCOGEN':
+        assert stats_py.solver_name == stats_cg.solver_name
     assert sol_cg.opt_val == val_cg
 
 def test_clarabel():

--- a/tests/test_E2E_LP.py
+++ b/tests/test_E2E_LP.py
@@ -153,6 +153,6 @@ def test_clarabel():
     test('network', 'CLARABEL', 'loops', 0)
     test('network', 'CLARABEL', 'loops', 1)
 
-def test_qoco():
-    test('network', 'QOCO', 'loops', 0)
-    test('network', 'QOCO', 'loops', 1)
+def test_qocogen():
+    test('network', 'QOCOGEN', 'loops', 0)
+    test('network', 'QOCOGEN', 'loops', 1)

--- a/tests/test_E2E_QP.py
+++ b/tests/test_E2E_QP.py
@@ -226,7 +226,9 @@ def test(name, solver, style, seed):
     else:
         assert np.linalg.norm(dual_cg, 2) < 1e-3
         
-    assert stats_py.solver_name == stats_cg.solver_name
+    # QOCOGEN is not in CVXPY, but QOCO is an identical (but non-customized) solver, so to check QOCOGEN, we use QOCO.
+    if stats_cg.solver_name != 'QOCOGEN':
+        assert stats_py.solver_name == stats_cg.solver_name
     assert sol_cg.opt_val == val_cg
 
     

--- a/tests/test_E2E_QP.py
+++ b/tests/test_E2E_QP.py
@@ -246,7 +246,7 @@ def test_OSQP_verbose():
     module = importlib.import_module('test_actuator_OSQP_verbose.cpg_solver')
     prob.register_solve('CPG', module.cpg_solve)
 
-    prob = assign_data(prob, 'actuaor', 0)
+    prob = assign_data(prob, 'actuator', 0)
 
     verbose_output = io.StringIO()
     sys.stdout = verbose_output

--- a/tests/test_E2E_QP.py
+++ b/tests/test_E2E_QP.py
@@ -177,7 +177,7 @@ def get_primal_vec(prob, name):
 N_RAND = 2
 
 name_solver_style_seed = [['actuator', 'MPC', 'portfolio'],
-                          ['OSQP', 'SCS', 'QOCO'],
+                          ['OSQP', 'SCS', 'QOCOGEN'],
                           ['loops'],
                           list(np.arange(N_RAND))]
 

--- a/tests/test_E2E_SOCP.py
+++ b/tests/test_E2E_SOCP.py
@@ -75,7 +75,7 @@ def get_primal_vec(prob, name):
 N_RAND = 2
 
 name_solver_style_seed = [['ADP'],
-                          ['SCS', 'ECOS', 'QOCO'],
+                          ['SCS', 'ECOS', 'QOCOGEN'],
                           ['unroll', 'loops'],
                           list(np.arange(N_RAND))]
 

--- a/tests/test_E2E_SOCP.py
+++ b/tests/test_E2E_SOCP.py
@@ -120,8 +120,10 @@ def test(name, solver, style, seed):
         assert np.linalg.norm(dual_cg - dual_py, 2) / dual_py_norm < 0.1
     else:
         assert np.linalg.norm(dual_cg, 2) < 1e-3
-        
-    assert stats_py.solver_name == stats_cg.solver_name
+    
+    # QOCOGEN is not in CVXPY, but QOCO is an identical (but non-customized) solver, so to check QOCOGEN, we use QOCO.
+    if stats_cg.solver_name != 'QOCOGEN':
+        assert stats_py.solver_name == stats_cg.solver_name
     assert sol_cg.opt_val == val_cg
 
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -28,6 +28,9 @@ def check(prob, solver, name, func_get_primal_vec, **extra_settings):
         val_py = prob.solve(solver='SCS', warm_start=False, verbose=False, **extra_settings)
     elif solver == 'CLARABEL':
         val_py = prob.solve(solver='CLARABEL', verbose=False, **extra_settings)
+    elif solver == 'QOCOGEN':
+        # QOCOGEN is not in CVXPY, but QOCO is an identical (but non-customized) solver.
+        val_py = prob.solve(solver='QOCO', **extra_settings)
     else:
         val_py = prob.solve(solver=solver, **extra_settings)
     prim_py = func_get_primal_vec(prob, name)


### PR DESCRIPTION
QOCO and QOCOGEN are two solvers which implement the same algorithm, but QOCOGEN generates custom linear algebra routines. This allows the solvers generated by QOCOGEN (called qoco_custom) to be faster, but results in long compile times especially for problems with many nonzeros.

Currently QOCOGEN is intergrated into CVXPYgen, but under the name 'QOCO', as my original plan was to integrate QOCO into CVXPY and QOCOGEN into CVXPYgen. However, due to the long compile times of QOCOGEN, in the near future I would like to make QOCO callable from CVXPYgen. 

To do this, the first step is to call QOCOGEN via CVXPYgen through the call `cpg.generate_code(problem, solver='QOCOGEN')` rather than the current  `cpg.generate_code(problem, solver='QOCO')`.

Sorry for any confusion this may cause.