### PR TITLE
Add QOCO

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,7 +73,5 @@ jobs:
         pip install pytest
         cd tests
         python -m pytest test_E2E_LP.py::test test_E2E_QP.py::test test_E2E_QP.py::test_OSQP_verbose test_E2E_SOCP.py::test test_E2E_LP.py::test_qocogen test_unsupported_solvers.py
-        dir /s /b qocostatic.lib
-        dir /s /b libqocostatic.lib
-        dir /s /b qdldl.lib
-        dir /s /b libqdldl.lib
+        gci -Recurse -Filter qocostatic.lib | select -ExpandProperty FullName
+        gci -Recurse -Filter qdldl.lib | select -ExpandProperty FullName

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,3 +73,7 @@ jobs:
         pip install pytest
         cd tests
         python -m pytest test_E2E_LP.py::test test_E2E_QP.py::test test_E2E_QP.py::test_OSQP_verbose test_E2E_SOCP.py::test test_E2E_LP.py::test_qocogen test_unsupported_solvers.py
+        dir /s /b qocostatic.lib
+        dir /s /b libqocostatic.lib
+        dir /s /b qdldl.lib
+        dir /s /b libqdldl.lib

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,4 +72,4 @@ jobs:
       run: |
         pip install pytest
         cd tests
-        python -m pytest test_E2E_LP.py::test test_E2E_QP.py::test test_E2E_QP.py::test_OSQP_verbose test_E2E_SOCP.py::test test_E2E_LP.py::test_qoco test_unsupported_solvers.py
+        python -m pytest test_E2E_LP.py::test test_E2E_QP.py::test test_E2E_QP.py::test_OSQP_verbose test_E2E_SOCP.py::test test_E2E_LP.py::test_qocogen test_unsupported_solvers.py

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,5 +73,3 @@ jobs:
         pip install pytest
         cd tests
         python -m pytest test_E2E_LP.py::test test_E2E_QP.py::test test_E2E_QP.py::test_OSQP_verbose test_E2E_SOCP.py::test test_E2E_LP.py::test_qocogen test_unsupported_solvers.py
-        gci -Recurse -Filter qocostatic.lib | select -ExpandProperty FullName
-        gci -Recurse -Filter qdldl.lib | select -ExpandProperty FullName

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "cvxpygen/solvers/Clarabel.cpp"]
 	path = cvxpygen/solvers/Clarabel.cpp
 	url = https://github.com/oxfordcontrol/Clarabel.cpp.git
+[submodule "cvxpygen/solvers/qoco"]
+	path = cvxpygen/solvers/qoco
+	url = https://github.com/qoco-org/qoco.git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -59,6 +59,8 @@ include cvxpygen/solvers/qoco/examples/*
 include cvxpygen/solvers/qoco/lib/*
 include cvxpygen/solvers/qoco/lib/amd/*
 include cvxpygen/solvers/qoco/lib/qdldl/*
-include cvxpygen/solvers/qoco/lib/qdldl/configure/*.in
+include cvxpygen/solvers/qoco/lib/qdldl/*
+include cvxpygen/solvers/qoco/lib/qdldl/configure/*
+include cvxpygen/solvers/qoco/lib/qdldl/configure/cmake/*
 include cvxpygen/solvers/qoco/lib/qdldl/include/*.h
 include cvxpygen/solvers/qoco/lib/qdldl/src/*.c

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -55,7 +55,6 @@ include cvxpygen/solvers/qoco/*
 include cvxpygen/solvers/qoco/src/*.c
 include cvxpygen/solvers/qoco/include/*.h
 include cvxpygen/solvers/qoco/configure/*
-include cvxpygen/solvers/qoco/examples/*
 include cvxpygen/solvers/qoco/lib/*
 include cvxpygen/solvers/qoco/lib/amd/*
 include cvxpygen/solvers/qoco/lib/qdldl/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -51,3 +51,11 @@ include cvxpygen/solvers/Clarabel.cpp/Clarabel.rs/src/solver/implementations/*.r
 include cvxpygen/solvers/Clarabel.cpp/Clarabel.rs/src/solver/implementations/default/*.rs
 include cvxpygen/solvers/Clarabel.cpp/Clarabel.rs/src/solver/utils/*.rs
 include cvxpygen/solvers/Clarabel.cpp/Clarabel.rs/src/timers/*.rs
+include cvxpygen/solvers/qoco/*
+include cvxpygen/solvers/qoco/src/*.c
+include cvxpygen/solvers/qoco/include/*.h
+include cvxpygen/solvers/qoco/configure/*
+include cvxpygen/solvers/qoco/lib/amd/*
+include cvxpygen/solvers/qoco/qdldl/*
+include cvxpygen/solvers/qoco/qdldl/include/*.h
+include cvxpygen/solvers/qoco/qdldl/src/*.c

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -56,7 +56,8 @@ include cvxpygen/solvers/qoco/src/*.c
 include cvxpygen/solvers/qoco/include/*.h
 include cvxpygen/solvers/qoco/configure/*
 include cvxpygen/solvers/qoco/examples/*
+include cvxpygen/solvers/qoco/lib/*
 include cvxpygen/solvers/qoco/lib/amd/*
-include cvxpygen/solvers/qoco/qdldl/*
-include cvxpygen/solvers/qoco/qdldl/include/*.h
-include cvxpygen/solvers/qoco/qdldl/src/*.c
+include cvxpygen/solvers/qoco/lib/qdldl/*
+include cvxpygen/solvers/qoco/lib/qdldl/include/*.h
+include cvxpygen/solvers/qoco/lib/qdldl/src/*.c

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -55,6 +55,7 @@ include cvxpygen/solvers/qoco/*
 include cvxpygen/solvers/qoco/src/*.c
 include cvxpygen/solvers/qoco/include/*.h
 include cvxpygen/solvers/qoco/configure/*
+include cvxpygen/solvers/qoco/examples/*
 include cvxpygen/solvers/qoco/lib/amd/*
 include cvxpygen/solvers/qoco/qdldl/*
 include cvxpygen/solvers/qoco/qdldl/include/*.h

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -59,5 +59,6 @@ include cvxpygen/solvers/qoco/examples/*
 include cvxpygen/solvers/qoco/lib/*
 include cvxpygen/solvers/qoco/lib/amd/*
 include cvxpygen/solvers/qoco/lib/qdldl/*
+include cvxpygen/solvers/qoco/lib/qdldl/configure/*.in
 include cvxpygen/solvers/qoco/lib/qdldl/include/*.h
 include cvxpygen/solvers/qoco/lib/qdldl/src/*.c

--- a/cvxpygen/cpg.py
+++ b/cvxpygen/cpg.py
@@ -90,15 +90,8 @@ def extract_canonicalization(problem, solver, solver_opts, enable_settings) -> C
 
     # QOCOGEN has an identical interface to QOCO, but only QOCO is in cvxpy.
     if solver == 'QOCOGEN':
-        data, _, inverse_data = problem.get_problem_data(
-            solver='QOCO',
-            gp=False,
-            enforce_dpp=True,
-            verbose=False,
-            solver_opts=solver_opts
-        )
-    else:
-        data, _, inverse_data = problem.get_problem_data(
+        solver = 'QOCO'
+    data, _, inverse_data = problem.get_problem_data(
         solver=solver,
         gp=False,
         enforce_dpp=True,

--- a/cvxpygen/cpg.py
+++ b/cvxpygen/cpg.py
@@ -87,7 +87,18 @@ def extract_canonicalization(problem, solver, solver_opts, enable_settings) -> C
     interface_class, cvxpy_interface_class = get_interface_class(solver)
     
     # problem data
-    data, _, inverse_data = problem.get_problem_data(
+
+    # QOCOGEN has an identical interface to QOCO, but only QOCO is in cvxpy.
+    if solver == 'QOCOGEN':
+        data, _, inverse_data = problem.get_problem_data(
+            solver='QOCO',
+            gp=False,
+            enforce_dpp=True,
+            verbose=False,
+            solver_opts=solver_opts
+        )
+    else:
+        data, _, inverse_data = problem.get_problem_data(
         solver=solver,
         gp=False,
         enforce_dpp=True,

--- a/cvxpygen/cpg.py
+++ b/cvxpygen/cpg.py
@@ -87,12 +87,8 @@ def extract_canonicalization(problem, solver, solver_opts, enable_settings) -> C
     interface_class, cvxpy_interface_class = get_interface_class(solver)
     
     # problem data
-
-    # QOCOGEN has an identical interface to QOCO, but only QOCO is in cvxpy.
-    if solver == 'QOCOGEN':
-        solver = 'QOCO'
     data, _, inverse_data = problem.get_problem_data(
-        solver=solver,
+        solver=cvxpy_interface_class.__name__,
         gp=False,
         enforce_dpp=True,
         verbose=False,

--- a/cvxpygen/solvers.py
+++ b/cvxpygen/solvers.py
@@ -38,7 +38,7 @@ def get_interface_class(solver_name: str) -> "SolverInterface":
     interface = mapping.get(solver_name.upper(), None)
     if interface is None:
         raise ValueError(f'Unsupported solver: {solver_name}.')
-    return interface[0], interface[1]
+    return interface
 
 
 class SolverInterface(ABC):

--- a/cvxpygen/solvers.py
+++ b/cvxpygen/solvers.py
@@ -1770,7 +1770,9 @@ class QOCOInterface(SolverInterface):
         # adjust setup.py
         setup_replacements = [
             ("os.path.join('c', 'solver_code', 'include'),",
-            "os.path.join('c', 'solver_code'),"),
+            "os.path.join('c', 'solver_code', 'include'),\n" +
+            indent + "os.path.join('c', 'solver_code', 'lib', 'amd'),\n" +
+            indent + "os.path.join('c', 'solver_code', 'lib', 'qdldl', 'include'),"),
             ("license='Apache 2.0'", "license='BSD 3-Clause'")
         ]
         read_write_file(os.path.join(code_dir, 'setup.py'),

--- a/cvxpygen/solvers.py
+++ b/cvxpygen/solvers.py
@@ -1749,31 +1749,33 @@ class QOCOInterface(SolverInterface):
             indent + sdir + 'lib/amd\n' +
             indent + sdir + 'lib/qdldl/include')
         ]
-
         read_write_file(os.path.join(code_dir, 'c', 'CMakeLists.txt'),
                         lambda x: multiple_replace(x, cmake_replacements))
-        
-        # cmake_replacements = [("# directories including header files", 
-        #                        "# directories including header files\n" + 
-        #                        'if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")\n' + 
-        #                        indent + 'add_compile_definitions(IS_LINUX)\n' + 
-        #                         'elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")\n' + 
-        #                        indent + 'add_compile_definitions(IS_MACOS)\n' + 
-        #                         'elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")\n' + 
-        #                        indent + 'add_compile_definitions(IS_WINDOWS)\n' + 
-        #                        'endif()'
-        #                        )]
 
-        # read_write_file(os.path.join(code_dir, 'c', 'CMakeLists.txt'),
-        #                 lambda x: multiple_replace(x, cmake_replacements))
+        cmake_replacements = [
+            ('add_executable (cpg_example ${cpg_head} ${cpg_src} ${CMAKE_CURRENT_SOURCE_DIR}/src/cpg_example.c)',
+            'add_executable (cpg_example ${cpg_head} ${cpg_src} ${CMAKE_CURRENT_SOURCE_DIR}/src/cpg_example.c)\n' +
+            'target_link_libraries(cpg_example qocostatic)')
+        ]
+        read_write_file(os.path.join(code_dir, 'c', 'CMakeLists.txt'),
+                        lambda x: multiple_replace(x, cmake_replacements))
+
+        cmake_replacements = [
+            ('add_library (cpg STATIC ${cpg_head} ${cpg_src})',
+            'add_library (cpg STATIC ${cpg_head} ${cpg_src})\n' +
+            'target_link_libraries(cpg qocostatic)')
+        ]
+        read_write_file(os.path.join(code_dir, 'c', 'CMakeLists.txt'),
+                        lambda x: multiple_replace(x, cmake_replacements))
 
         # adjust setup.py
         setup_replacements = [
             ("os.path.join('c', 'solver_code', 'include'),",
             "os.path.join('c', 'solver_code', 'include'),\n" +
-            indent + "os.path.join('c', 'solver_code', 'lib', 'amd'),\n" +
-            indent + "os.path.join('c', 'solver_code', 'lib', 'qdldl', 'include'),"),
-            ("license='Apache 2.0'", "license='BSD 3-Clause'")
+            5 * indent + "os.path.join('c', 'solver_code', 'lib', 'amd'),\n" +
+            5 * indent + "os.path.join('c', 'solver_code', 'lib', 'qdldl', 'include'),"),
+            ("license='Apache 2.0'", "license='BSD 3-Clause'"),
+            ('extra_objects=[cpg_lib]', "extra_objects=[cpg_lib, os.path.join(cpg_dir, 'build', 'out', 'libqocostatic.a')]")
         ]
         read_write_file(os.path.join(code_dir, 'setup.py'),
                         lambda x: multiple_replace(x, setup_replacements))

--- a/cvxpygen/solvers.py
+++ b/cvxpygen/solvers.py
@@ -1476,11 +1476,11 @@ class QOCOGENInterface(SolverInterface):
     stgs_direct_write_ptr = '(&({prefix}qoco_custom_workspace.settings))'
     stgs_translation = "{}"
     stgs_reset_function = {'name': 'set_default_settings', 'ptr': '&{prefix}qoco_custom_workspace'}
-    stgs_names = ['max_iters', 'bisect_iters', 'iter_ref_iters', 'kkt_static_reg', 'kkt_dynamic_reg',
+    stgs_names = ['max_iters', 'bisect_iters', 'ruiz_iters', 'iter_ref_iters', 'kkt_static_reg', 'kkt_dynamic_reg',
                       'abstol', 'reltol', 'abstol_inacc', 'reltol_inacc', 'verbose']
     stgs_types = ['cpg_int', 'cpg_int', 'cpg_int', 'cpg_float', 'cpg_float', 'cpg_float', 'cpg_float', 'cpg_float', 'cpg_float', 'cpg_int']
     stgs_enabled = [True, True, True, True, True, True, True, True, True, True]
-    stgs_defaults = ['200', '5', '1', '1e-8', '1e-8', '1e-7', '1e-7', '1e-5', '1e-5', '0']
+    stgs_defaults = ['200', '5', '0', '1', '1e-8', '1e-8', '1e-7', '1e-7', '1e-5', '1e-5', '0']
 
     dual_var_split = True
     dual_var_names = ['y', 'z']

--- a/cvxpygen/solvers.py
+++ b/cvxpygen/solvers.py
@@ -1823,7 +1823,7 @@ class QOCOInterface(SolverInterface):
             5 * indent + "os.path.join('c', 'solver_code', 'lib', 'amd'),\n" +
             5 * indent + "os.path.join('c', 'solver_code', 'lib', 'qdldl', 'include'),"),
             ("license='Apache 2.0'", "license='BSD 3-Clause'"),
-            ("lib_name = 'cpg.lib'", "lib_name = 'cpg.lib'\n" + "    libqoco_name = 'qocostatic.lib'\n" + "    libqdldl_name = 'qdldl.lib'"),
+            ("lib_name = 'cpg.lib'", "lib_name = os.path.join('cpg.lib')\n" + "    libqoco_name = os.path.join('Release', 'qocostatic.lib')\n" + "    libqdldl_name = os.path.join('Release', 'qdldl.lib')"),
             ("lib_name = 'libcpg.a'", "lib_name = 'libcpg.a'\n" + "    libqoco_name = 'libqocostatic.a'\n" + "    libqdldl_name = 'libqdldl.a'"),
             ('extra_objects=[cpg_lib]', "extra_objects=[cpg_lib, os.path.join(cpg_dir, 'build', 'out', libqoco_name), os.path.join(cpg_dir, 'build', 'solver_code', 'lib', 'qdldl', 'out', libqdldl_name)]")
         ]

--- a/cvxpygen/solvers.py
+++ b/cvxpygen/solvers.py
@@ -1674,16 +1674,19 @@ class QOCOInterface(SolverInterface):
 
         self.parameter_update_structure = {
             'init': ParameterUpdateLogic(
-                update_pending_logic=UpdatePendingLogic([], extra_condition='!{prefix}qoco_solver', functions_if_false=['AbcGh']),
-                # function_call=f'{{prefix}}cpg_copy_all();\n'
-                #             f'    {{prefix}}ecos_workspace = ECOS_setup({canon_constants["n"]}, {canon_constants["m"]}, {canon_constants["p"]}, {canon_constants["l"]}, {canon_constants["n_cones"]}'
-                #             f', {"0" if canon_constants["n_cones"] == 0 else "(int *) &{prefix}ecos_q"}, {canon_constants["e"]}'
-                #             f', {{prefix}}Canon_Params_conditioning.G->x, {{prefix}}Canon_Params_conditioning.G->p, {{prefix}}Canon_Params_conditioning.G->i'
-                #             f', {"0" if canon_constants["p"] == 0 else "{prefix}Canon_Params_conditioning.A->x"}'
-                #             f', {"0" if canon_constants["p"] == 0 else "{prefix}Canon_Params_conditioning.A->p"}'
-                #             f', {"0" if canon_constants["p"] == 0 else "{prefix}Canon_Params_conditioning.A->i"}'
-                #             f', {{prefix}}Canon_Params_conditioning.c, {{prefix}}Canon_Params_conditioning.h'
-                #             f', {"0" if canon_constants["p"] == 0 else "{prefix}Canon_Params_conditioning.b"})'
+                update_pending_logic=UpdatePendingLogic([], extra_condition='!{prefix}qoco_solver'),
+                function_call=f'{{prefix}}cpg_copy_all();\n'
+                            f'   QOCOCscMatrix* P = (QOCOCscMatrix*)malloc(sizeof(QOCOCscMatrix));\n'
+                            f'   QOCOCscMatrix* A = (QOCOCscMatrix*)malloc(sizeof(QOCOCscMatrix));\n'
+                            f'   QOCOCscMatrix* G = (QOCOCscMatrix*)malloc(sizeof(QOCOCscMatrix));\n'
+                            f'   qoco_set_csc(P, {canon_constants["n"]}, {canon_constants["n"]}, Canon_Params.P->nnz, Canon_Params.P->x, Canon_Params.P->p, Canon_Params.P->i);\n'
+                            f'   qoco_set_csc(A, {canon_constants["p"]}, {canon_constants["n"]}, Canon_Params.A->nnz, Canon_Params.A->x, Canon_Params.A->p, Canon_Params.A->i);\n'
+                            f'   qoco_set_csc(G, {canon_constants["m"]}, {canon_constants["n"]}, Canon_Params.G->nnz, Canon_Params.G->x, Canon_Params.G->p, Canon_Params.G->i);\n'
+                            f'   QOCOSettings* settings = (QOCOSettings*)malloc(sizeof(QOCOSettings));\n'
+                            f'   set_default_settings(settings);\n'
+                            f'   {{prefix}}qoco_solver = (QOCOSolver*)malloc(sizeof(QOCOSolver));\n'
+                            f'    qoco_setup({{prefix}}qoco_solver, {canon_constants["n"]}, {canon_constants["m"]}, {canon_constants["p"]}, P, Canon_Params.c, A, Canon_Params.b, G, Canon_Params.h, {canon_constants["l"]}, {canon_constants["nsoc"]}'
+                            f', {"NULL" if canon_constants["nsoc"] == 0 else "(int *) &{prefix}qoco_q"}, settings);'
             ),
             'A': ParameterUpdateLogic(
                 update_pending_logic = UpdatePendingLogic(['A']),

--- a/cvxpygen/solvers.py
+++ b/cvxpygen/solvers.py
@@ -1775,7 +1775,7 @@ class QOCOInterface(SolverInterface):
             5 * indent + "os.path.join('c', 'solver_code', 'lib', 'amd'),\n" +
             5 * indent + "os.path.join('c', 'solver_code', 'lib', 'qdldl', 'include'),"),
             ("license='Apache 2.0'", "license='BSD 3-Clause'"),
-            ('extra_objects=[cpg_lib]', "extra_objects=[cpg_lib, os.path.join(cpg_dir, 'build', 'out', 'libqocostatic.a')]")
+            ('extra_objects=[cpg_lib]', "extra_objects=[cpg_lib, os.path.join(cpg_dir, 'build', 'out', 'libqocostatic.a'), os.path.join(cpg_dir, 'build', 'solver_code', 'lib', 'qdldl', 'out', 'libqdldl.a')]")
         ]
         read_write_file(os.path.join(code_dir, 'setup.py'),
                         lambda x: multiple_replace(x, setup_replacements))

--- a/cvxpygen/solvers.py
+++ b/cvxpygen/solvers.py
@@ -1775,7 +1775,7 @@ class QOCOInterface(SolverInterface):
         if os.path.isdir(solver_code_dir):
             shutil.rmtree(solver_code_dir)
         os.mkdir(solver_code_dir)
-        dirs_to_copy = ['src', 'include', 'lib', 'examples', 'configure']
+        dirs_to_copy = ['src', 'include', 'lib', 'configure']
         for dtc in dirs_to_copy:
             shutil.copytree(os.path.join(cvxpygen_directory, 'solvers', 'qoco', dtc),
                             os.path.join(solver_code_dir, dtc))

--- a/cvxpygen/solvers.py
+++ b/cvxpygen/solvers.py
@@ -1672,21 +1672,57 @@ class QOCOInterface(SolverInterface):
                            'nsoc': len(p_prob.cone_dims.soc),
                            'q': q}
 
+        function_call = (
+            f'{{prefix}}cpg_copy_all();\n'
+            '   QOCOCscMatrix* P = (QOCOCscMatrix*)malloc(sizeof(QOCOCscMatrix));\n'
+            '   QOCOCscMatrix* A = (QOCOCscMatrix*)malloc(sizeof(QOCOCscMatrix));\n'
+            '   QOCOCscMatrix* G = (QOCOCscMatrix*)malloc(sizeof(QOCOCscMatrix));\n'
+        )
+
+        if indices_obj is not None:
+            function_call += (
+                f'   qoco_set_csc(P, {canon_constants["n"]}, {canon_constants["n"]}, '
+                f'{{prefix}}Canon_Params.P->nnz, {{prefix}}Canon_Params.P->x, '
+                f'{{prefix}}Canon_Params.P->p, {{prefix}}Canon_Params.P->i);\n'
+            )
+        else:
+            function_call += '   P = NULL;\n'
+
+        if canon_constants["p"] > 0:
+            function_call += (
+                f'   qoco_set_csc(A, {canon_constants["p"]}, {canon_constants["n"]}, '
+                f'{{prefix}}Canon_Params.A->nnz, {{prefix}}Canon_Params.A->x, '
+                f'{{prefix}}Canon_Params.A->p, {{prefix}}Canon_Params.A->i);\n'
+            )
+        else:
+            function_call += '   A = NULL;\n'
+
+        if canon_constants["m"] > 0:
+            function_call += (
+                f'   qoco_set_csc(G, {canon_constants["m"]}, {canon_constants["n"]}, '
+                f'{{prefix}}Canon_Params.G->nnz, {{prefix}}Canon_Params.G->x, '
+                f'{{prefix}}Canon_Params.G->p, {{prefix}}Canon_Params.G->i);\n'
+            )
+        else:
+            function_call += '   G = NULL;\n'
+
+        function_call += (
+            '   QOCOSettings* qoco_settings = (QOCOSettings*)malloc(sizeof(QOCOSettings));\n'
+            '   set_default_settings(qoco_settings);\n'
+            f'   {{prefix}}qoco_solver = (QOCOSolver*)malloc(sizeof(QOCOSolver));\n'
+            f'   qoco_setup({{prefix}}qoco_solver, {canon_constants["n"]}, {canon_constants["m"]}, {canon_constants["p"]}, P, '
+            f'{{prefix}}Canon_Params.c, A, '
+            f'{"NULL" if canon_constants["p"] == 0 else f"{{prefix}}Canon_Params.b"}, '
+            f'G, {"NULL" if canon_constants["m"] == 0 else f"{{prefix}}Canon_Params.h"}, '
+            f'{canon_constants["l"]}, {canon_constants["nsoc"]}, '
+            f'{"NULL" if canon_constants["nsoc"] == 0 else f"(int *) &{{prefix}}qoco_q"}, '
+            'qoco_settings)'
+        )
+
         self.parameter_update_structure = {
             'init': ParameterUpdateLogic(
                 update_pending_logic=UpdatePendingLogic([], extra_condition='!{prefix}qoco_solver'),
-                function_call=f'{{prefix}}cpg_copy_all();\n'
-                            f'   QOCOCscMatrix* P = (QOCOCscMatrix*)malloc(sizeof(QOCOCscMatrix));\n'
-                            f'   QOCOCscMatrix* A = (QOCOCscMatrix*)malloc(sizeof(QOCOCscMatrix));\n'
-                            f'   QOCOCscMatrix* G = (QOCOCscMatrix*)malloc(sizeof(QOCOCscMatrix));\n'
-                            f'{f'   qoco_set_csc(P, {canon_constants["n"]}, {canon_constants["n"]}, {{prefix}}Canon_Params.P->nnz, {{prefix}}Canon_Params.P->x, {{prefix}}Canon_Params.P->p, {{prefix}}Canon_Params.P->i);\n' if indices_obj is not None else 'P = NULL;\n'}'
-                            f'{f'   qoco_set_csc(A, {canon_constants["p"]}, {canon_constants["n"]}, {{prefix}}Canon_Params.A->nnz, {{prefix}}Canon_Params.A->x, {{prefix}}Canon_Params.A->p, {{prefix}}Canon_Params.A->i);\n' if canon_constants["p"] > 0 else 'A = NULL;\n'}'
-                            f'{f'   qoco_set_csc(G, {canon_constants["m"]}, {canon_constants["n"]}, {{prefix}}Canon_Params.G->nnz, {{prefix}}Canon_Params.G->x, {{prefix}}Canon_Params.G->p, {{prefix}}Canon_Params.G->i);\n' if canon_constants["m"] > 0 else 'G = NULL;\n'}'
-                            f'   QOCOSettings* qoco_settings = (QOCOSettings*)malloc(sizeof(QOCOSettings));\n'
-                            f'   set_default_settings(qoco_settings);\n'
-                            f'   {{prefix}}qoco_solver = (QOCOSolver*)malloc(sizeof(QOCOSolver));\n'
-                            f'    qoco_setup({{prefix}}qoco_solver, {canon_constants["n"]}, {canon_constants["m"]}, {canon_constants["p"]}, P, {{prefix}}Canon_Params.c, A, {"NULL" if canon_constants["p"] == 0 else f" {{prefix}}Canon_Params.b"}, G, {"NULL" if canon_constants["m"] == 0 else f" {{prefix}}Canon_Params.h"}, {canon_constants["l"]}, {canon_constants["nsoc"]}'
-                            f', {"NULL" if canon_constants["nsoc"] == 0 else "(int *) &{prefix}qoco_q"}, qoco_settings)'
+                function_call=function_call
             ),
             'A': ParameterUpdateLogic(
                 update_pending_logic = UpdatePendingLogic(['A']),

--- a/cvxpygen/solvers.py
+++ b/cvxpygen/solvers.py
@@ -1606,7 +1606,7 @@ class QOCOInterface(SolverInterface):
     canon_p_ids = ['P', 'c', 'd', 'A', 'b', 'G', 'h']
     canon_p_ids_constr_vec = ['b', 'h']
     supports_gradient = False
-    solve_function_call = '{prefix}qoco_solve = qoco_solve({prefix}qoco_solver)'
+    solve_function_call = 'qoco_solve({prefix}qoco_solver)'
 
     # header files
     header_files = ['"qoco.h"']
@@ -1625,7 +1625,7 @@ class QOCOInterface(SolverInterface):
         primal_residual = 'qoco_solver->sol->pres',
         dual_residual = 'qoco_solver->sol->dres',
         primal_solution = 'qoco_solver->sol->x',
-        dual_solution = 'qoco_solver->{dual_var_name}',
+        dual_solution = 'qoco_solver->sol->{dual_var_name}',
         settings = 'qoco_solver->settings->{setting_name}'
     )
 
@@ -1727,7 +1727,7 @@ class QOCOInterface(SolverInterface):
         if os.path.isdir(solver_code_dir):
             shutil.rmtree(solver_code_dir)
         os.mkdir(solver_code_dir)
-        dirs_to_copy = ['src', 'include', 'lib', 'examples']
+        dirs_to_copy = ['src', 'include', 'lib', 'examples', 'configure']
         for dtc in dirs_to_copy:
             shutil.copytree(os.path.join(cvxpygen_directory, 'solvers', 'qoco', dtc),
                             os.path.join(solver_code_dir, dtc))
@@ -1752,6 +1752,20 @@ class QOCOInterface(SolverInterface):
 
         read_write_file(os.path.join(code_dir, 'c', 'CMakeLists.txt'),
                         lambda x: multiple_replace(x, cmake_replacements))
+        
+        # cmake_replacements = [("# directories including header files", 
+        #                        "# directories including header files\n" + 
+        #                        'if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")\n' + 
+        #                        indent + 'add_compile_definitions(IS_LINUX)\n' + 
+        #                         'elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")\n' + 
+        #                        indent + 'add_compile_definitions(IS_MACOS)\n' + 
+        #                         'elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")\n' + 
+        #                        indent + 'add_compile_definitions(IS_WINDOWS)\n' + 
+        #                        'endif()'
+        #                        )]
+
+        # read_write_file(os.path.join(code_dir, 'c', 'CMakeLists.txt'),
+        #                 lambda x: multiple_replace(x, cmake_replacements))
 
         # adjust setup.py
         setup_replacements = [

--- a/cvxpygen/solvers.py
+++ b/cvxpygen/solvers.py
@@ -1643,14 +1643,12 @@ class QOCOInterface(SolverInterface):
     stgs_requires_extra_struct_type = True
     stgs_direct_write_ptr = None
     stgs_reset_function = None
-    stgs_names = ['feastol', 'abstol', 'reltol', 'feastol_inacc', 'abstol_inacc',
-                      'reltol_inacc', 'maxit']
     stgs_translation = "{}"
-    stgs_names = ['max_iters', 'bisect_iters', 'iter_ref_iters', 'kkt_static_reg', 'kkt_dynamic_reg',
+    stgs_names = ['max_iters', 'bisect_iters', 'ruiz_iters', 'iter_ref_iters', 'kkt_static_reg', 'kkt_dynamic_reg',
                       'abstol', 'reltol', 'abstol_inacc', 'reltol_inacc', 'verbose']
-    stgs_types = ['cpg_int', 'cpg_int', 'cpg_int', 'cpg_float', 'cpg_float', 'cpg_float', 'cpg_float', 'cpg_float', 'cpg_float', 'cpg_int']
-    stgs_enabled = [True, True, True, True, True, True, True, True, True, True]
-    stgs_defaults = ['200', '5', '1', '1e-8', '1e-8', '1e-7', '1e-7', '1e-5', '1e-5', '0']
+    stgs_types = ['cpg_int', 'cpg_int', 'cpg_int', 'cpg_int', 'cpg_float', 'cpg_float', 'cpg_float', 'cpg_float', 'cpg_float', 'cpg_float', 'cpg_int']
+    stgs_enabled = [True, True, True, True, True, True, True, True, True, True, True]
+    stgs_defaults = ['200', '5', '0', '1', '1e-8', '1e-8', '1e-7', '1e-7', '1e-5', '1e-5', '0']
 
     # dual variables split into y and z vectors
     dual_var_split = True

--- a/cvxpygen/solvers.py
+++ b/cvxpygen/solvers.py
@@ -1823,7 +1823,9 @@ class QOCOInterface(SolverInterface):
             5 * indent + "os.path.join('c', 'solver_code', 'lib', 'amd'),\n" +
             5 * indent + "os.path.join('c', 'solver_code', 'lib', 'qdldl', 'include'),"),
             ("license='Apache 2.0'", "license='BSD 3-Clause'"),
-            ('extra_objects=[cpg_lib]', "extra_objects=[cpg_lib, os.path.join(cpg_dir, 'build', 'out', 'libqocostatic.a'), os.path.join(cpg_dir, 'build', 'solver_code', 'lib', 'qdldl', 'out', 'libqdldl.a')]")
+            ("lib_name = 'cpg.lib'", "lib_name = 'cpg.lib'\n" + "    libqoco_name = 'qocostatic.lib'\n" + "    libqdldl_name = 'qdldl.lib'"),
+            ("lib_name = 'libcpg.a'", "lib_name = 'libcpg.a'\n" + "    libqoco_name = 'libqocostatic.a'\n" + "    libqdldl_name = 'libqdldl.a'"),
+            ('extra_objects=[cpg_lib]', "extra_objects=[cpg_lib, os.path.join(cpg_dir, 'build', 'out', libqoco_name), os.path.join(cpg_dir, 'build', 'solver_code', 'lib', 'qdldl', 'out', libqdldl_name)]")
         ]
         read_write_file(os.path.join(code_dir, 'setup.py'),
                         lambda x: multiple_replace(x, setup_replacements))

--- a/cvxpygen/solvers.py
+++ b/cvxpygen/solvers.py
@@ -32,7 +32,7 @@ def get_interface_class(solver_name: str) -> "SolverInterface":
         'SCS': (SCSInterface, SCS),
         'ECOS': (ECOSInterface, ECOS),
         'CLARABEL': (ClarabelInterface, CLARABEL),
-        'QOCO': (QOCOGENInterface, QOCO),
+        'QOCOGEN': (QOCOGENInterface, QOCO),
     }
     interface = mapping.get(solver_name.upper(), None)
     if interface is None:
@@ -1539,7 +1539,7 @@ class QOCOGENInterface(SolverInterface):
     def check_unsupported_cones(cone_dims: "ConeDims") -> None:
         if cone_dims.exp > 0:
             raise ValueError(
-                'Code generation with ECOS and exponential cones is not supported yet.')
+                'Exponential cones is not supported for QOCOGEN.')
 
     @staticmethod
     def ret_prim_func_exists(variable_info: PrimalVariableInfo) -> bool:

--- a/cvxpygen/solvers.py
+++ b/cvxpygen/solvers.py
@@ -1682,11 +1682,11 @@ class QOCOInterface(SolverInterface):
                             f'   qoco_set_csc(P, {canon_constants["n"]}, {canon_constants["n"]}, Canon_Params.P->nnz, Canon_Params.P->x, Canon_Params.P->p, Canon_Params.P->i);\n'
                             f'   qoco_set_csc(A, {canon_constants["p"]}, {canon_constants["n"]}, Canon_Params.A->nnz, Canon_Params.A->x, Canon_Params.A->p, Canon_Params.A->i);\n'
                             f'   qoco_set_csc(G, {canon_constants["m"]}, {canon_constants["n"]}, Canon_Params.G->nnz, Canon_Params.G->x, Canon_Params.G->p, Canon_Params.G->i);\n'
-                            f'   QOCOSettings* settings = (QOCOSettings*)malloc(sizeof(QOCOSettings));\n'
-                            f'   set_default_settings(settings);\n'
+                            f'   QOCOSettings* qoco_settings = (QOCOSettings*)malloc(sizeof(QOCOSettings));\n'
+                            f'   set_default_settings(qoco_settings);\n'
                             f'   {{prefix}}qoco_solver = (QOCOSolver*)malloc(sizeof(QOCOSolver));\n'
                             f'    qoco_setup({{prefix}}qoco_solver, {canon_constants["n"]}, {canon_constants["m"]}, {canon_constants["p"]}, P, Canon_Params.c, A, Canon_Params.b, G, Canon_Params.h, {canon_constants["l"]}, {canon_constants["nsoc"]}'
-                            f', {"NULL" if canon_constants["nsoc"] == 0 else "(int *) &{prefix}qoco_q"}, settings);'
+                            f', {"NULL" if canon_constants["nsoc"] == 0 else "(int *) &{prefix}qoco_q"}, qoco_settings)'
             ),
             'A': ParameterUpdateLogic(
                 update_pending_logic = UpdatePendingLogic(['A']),

--- a/tests/test_E2E_LP.py
+++ b/tests/test_E2E_LP.py
@@ -147,8 +147,8 @@ def test(name, solver, style, seed):
         assert np.linalg.norm(dual_cg, 2) < 1e-3
 
     # QOCOGEN is not in CVXPY, but QOCO is an identical (but non-customized) solver, so to check QOCOGEN, we use QOCO.
-    if stats_cg.solver_name == 'QOCOGEN':
-        assert stats_py.solver_name == 'QOCO'
+    if solver == 'QOCOGEN':
+        assert stats_cg.solver_name == 'QOCOGEN'
     else:
         assert stats_py.solver_name == stats_cg.solver_name
     assert sol_cg.opt_val == val_cg

--- a/tests/test_E2E_LP.py
+++ b/tests/test_E2E_LP.py
@@ -147,7 +147,9 @@ def test(name, solver, style, seed):
         assert np.linalg.norm(dual_cg, 2) < 1e-3
 
     # QOCOGEN is not in CVXPY, but QOCO is an identical (but non-customized) solver, so to check QOCOGEN, we use QOCO.
-    if stats_cg.solver_name != 'QOCOGEN':
+    if stats_cg.solver_name == 'QOCOGEN':
+        assert stats_py.solver_name == 'QOCO'
+    else:
         assert stats_py.solver_name == stats_cg.solver_name
     assert sol_cg.opt_val == val_cg
 

--- a/tests/test_E2E_LP.py
+++ b/tests/test_E2E_LP.py
@@ -146,7 +146,9 @@ def test(name, solver, style, seed):
     else:
         assert np.linalg.norm(dual_cg, 2) < 1e-3
 
-    assert stats_py.solver_name == stats_cg.solver_name
+    # QOCOGEN is not in CVXPY, but QOCO is an identical (but non-customized) solver, so to check QOCOGEN, we use QOCO.
+    if stats_cg.solver_name != 'QOCOGEN':
+        assert stats_py.solver_name == stats_cg.solver_name
     assert sol_cg.opt_val == val_cg
 
 def test_clarabel():

--- a/tests/test_E2E_LP.py
+++ b/tests/test_E2E_LP.py
@@ -153,6 +153,6 @@ def test_clarabel():
     test('network', 'CLARABEL', 'loops', 0)
     test('network', 'CLARABEL', 'loops', 1)
 
-def test_qoco():
-    test('network', 'QOCO', 'loops', 0)
-    test('network', 'QOCO', 'loops', 1)
+def test_qocogen():
+    test('network', 'QOCOGEN', 'loops', 0)
+    test('network', 'QOCOGEN', 'loops', 1)

--- a/tests/test_E2E_LP.py
+++ b/tests/test_E2E_LP.py
@@ -99,7 +99,7 @@ def get_primal_vec(prob, name):
 N_RAND = 2
 
 name_solver_style_seed = [['network', 'resource'],
-                          ['ECOS'],
+                          ['ECOS', 'QOCO'],
                           ['loops'],
                           list(np.arange(N_RAND))]
 

--- a/tests/test_E2E_QP.py
+++ b/tests/test_E2E_QP.py
@@ -227,8 +227,8 @@ def test(name, solver, style, seed):
         assert np.linalg.norm(dual_cg, 2) < 1e-3
         
     # QOCOGEN is not in CVXPY, but QOCO is an identical (but non-customized) solver, so to check QOCOGEN, we use QOCO.
-    if stats_cg.solver_name == 'QOCOGEN':
-        assert stats_py.solver_name == 'QOCO'
+    if solver == 'QOCOGEN':
+        assert stats_cg.solver_name == 'QOCOGEN'
     else:
         assert stats_py.solver_name == stats_cg.solver_name
     assert sol_cg.opt_val == val_cg

--- a/tests/test_E2E_QP.py
+++ b/tests/test_E2E_QP.py
@@ -226,7 +226,9 @@ def test(name, solver, style, seed):
     else:
         assert np.linalg.norm(dual_cg, 2) < 1e-3
         
-    assert stats_py.solver_name == stats_cg.solver_name
+    # QOCOGEN is not in CVXPY, but QOCO is an identical (but non-customized) solver, so to check QOCOGEN, we use QOCO.
+    if stats_cg.solver_name != 'QOCOGEN':
+        assert stats_py.solver_name == stats_cg.solver_name
     assert sol_cg.opt_val == val_cg
 
     

--- a/tests/test_E2E_QP.py
+++ b/tests/test_E2E_QP.py
@@ -246,7 +246,7 @@ def test_OSQP_verbose():
     module = importlib.import_module('test_actuator_OSQP_verbose.cpg_solver')
     prob.register_solve('CPG', module.cpg_solve)
 
-    prob = assign_data(prob, 'actuaor', 0)
+    prob = assign_data(prob, 'actuator', 0)
 
     verbose_output = io.StringIO()
     sys.stdout = verbose_output

--- a/tests/test_E2E_QP.py
+++ b/tests/test_E2E_QP.py
@@ -227,7 +227,9 @@ def test(name, solver, style, seed):
         assert np.linalg.norm(dual_cg, 2) < 1e-3
         
     # QOCOGEN is not in CVXPY, but QOCO is an identical (but non-customized) solver, so to check QOCOGEN, we use QOCO.
-    if stats_cg.solver_name != 'QOCOGEN':
+    if stats_cg.solver_name == 'QOCOGEN':
+        assert stats_py.solver_name == 'QOCO'
+    else:
         assert stats_py.solver_name == stats_cg.solver_name
     assert sol_cg.opt_val == val_cg
 

--- a/tests/test_E2E_QP.py
+++ b/tests/test_E2E_QP.py
@@ -177,7 +177,7 @@ def get_primal_vec(prob, name):
 N_RAND = 2
 
 name_solver_style_seed = [['actuator', 'MPC', 'portfolio'],
-                          ['OSQP', 'SCS', 'QOCOGEN'],
+                          ['OSQP', 'SCS', 'QOCO', 'QOCOGEN'],
                           ['loops'],
                           list(np.arange(N_RAND))]
 

--- a/tests/test_E2E_QP.py
+++ b/tests/test_E2E_QP.py
@@ -177,7 +177,7 @@ def get_primal_vec(prob, name):
 N_RAND = 2
 
 name_solver_style_seed = [['actuator', 'MPC', 'portfolio'],
-                          ['OSQP', 'SCS', 'QOCO'],
+                          ['OSQP', 'SCS', 'QOCOGEN'],
                           ['loops'],
                           list(np.arange(N_RAND))]
 

--- a/tests/test_E2E_SOCP.py
+++ b/tests/test_E2E_SOCP.py
@@ -122,8 +122,8 @@ def test(name, solver, style, seed):
         assert np.linalg.norm(dual_cg, 2) < 1e-3
     
     # QOCOGEN is not in CVXPY, but QOCO is an identical (but non-customized) solver, so to check QOCOGEN, we use QOCO.
-    if stats_cg.solver_name == 'QOCOGEN':
-        assert stats_py.solver_name == 'QOCO'
+    if solver == 'QOCOGEN':
+        assert stats_cg.solver_name == 'QOCOGEN'
     else:
         assert stats_py.solver_name == stats_cg.solver_name
     assert sol_cg.opt_val == val_cg

--- a/tests/test_E2E_SOCP.py
+++ b/tests/test_E2E_SOCP.py
@@ -75,7 +75,7 @@ def get_primal_vec(prob, name):
 N_RAND = 2
 
 name_solver_style_seed = [['ADP'],
-                          ['SCS', 'ECOS', 'QOCO'],
+                          ['SCS', 'ECOS', 'QOCOGEN'],
                           ['unroll', 'loops'],
                           list(np.arange(N_RAND))]
 

--- a/tests/test_E2E_SOCP.py
+++ b/tests/test_E2E_SOCP.py
@@ -122,7 +122,9 @@ def test(name, solver, style, seed):
         assert np.linalg.norm(dual_cg, 2) < 1e-3
     
     # QOCOGEN is not in CVXPY, but QOCO is an identical (but non-customized) solver, so to check QOCOGEN, we use QOCO.
-    if stats_cg.solver_name != 'QOCOGEN':
+    if stats_cg.solver_name == 'QOCOGEN':
+        assert stats_py.solver_name == 'QOCO'
+    else:
         assert stats_py.solver_name == stats_cg.solver_name
     assert sol_cg.opt_val == val_cg
 

--- a/tests/test_E2E_SOCP.py
+++ b/tests/test_E2E_SOCP.py
@@ -75,7 +75,7 @@ def get_primal_vec(prob, name):
 N_RAND = 2
 
 name_solver_style_seed = [['ADP'],
-                          ['SCS', 'ECOS', 'QOCOGEN'],
+                          ['SCS', 'ECOS', 'QOCO', 'QOCOGEN'],
                           ['unroll', 'loops'],
                           list(np.arange(N_RAND))]
 

--- a/tests/test_E2E_SOCP.py
+++ b/tests/test_E2E_SOCP.py
@@ -120,8 +120,10 @@ def test(name, solver, style, seed):
         assert np.linalg.norm(dual_cg - dual_py, 2) / dual_py_norm < 0.1
     else:
         assert np.linalg.norm(dual_cg, 2) < 1e-3
-        
-    assert stats_py.solver_name == stats_cg.solver_name
+    
+    # QOCOGEN is not in CVXPY, but QOCO is an identical (but non-customized) solver, so to check QOCOGEN, we use QOCO.
+    if stats_cg.solver_name != 'QOCOGEN':
+        assert stats_py.solver_name == stats_cg.solver_name
     assert sol_cg.opt_val == val_cg
 
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -28,6 +28,9 @@ def check(prob, solver, name, func_get_primal_vec, **extra_settings):
         val_py = prob.solve(solver='SCS', warm_start=False, verbose=False, **extra_settings)
     elif solver == 'CLARABEL':
         val_py = prob.solve(solver='CLARABEL', verbose=False, **extra_settings)
+    elif solver == 'QOCOGEN':
+        # QOCOGEN is not in CVXPY, but QOCO is an identical (but non-customized) solver.
+        val_py = prob.solve(solver='QOCO', **extra_settings)
     else:
         val_py = prob.solve(solver=solver, **extra_settings)
     prim_py = func_get_primal_vec(prob, name)


### PR DESCRIPTION
QOCO and QOCOGEN are two solvers which implement the same algorithm, but QOCOGEN generates custom linear algebra routines. This allows the solvers generated by QOCOGEN (called qoco_custom) to be faster, but results in long compile times especially for problems with many nonzeros.

Currently QOCOGEN is intergrated into CVXPYgen, but under the name 'QOCO', as my original plan was to integrate QOCO into CVXPY and QOCOGEN into CVXPYgen. 

This PR integrates QOCO into CVXPYgen.
