### PR TITLE
Copy over qocogen license.

### DIFF
--- a/cvxpygen/solvers.py
+++ b/cvxpygen/solvers.py
@@ -1563,6 +1563,10 @@ class QOCOGENInterface(SolverInterface):
                                 self.canon_constants['l'], self.canon_constants['nsoc'], self.canon_constants['q'],
                                 os.path.join(code_dir, 'c'), "solver_code")
         
+        # Copy LICENSE
+        shutil.copyfile(os.path.join(code_dir, 'c', 'solver_code', 'LICENSE'),
+                os.path.join(code_dir, 'LICENSE'))
+
         # adjust top-level CMakeLists.txt
         sdir = '${CMAKE_CURRENT_SOURCE_DIR}/solver_code/'
         cmake_replacements = [

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'clarabel >= 0.6.0',
         'scipy >= 1.13.1',
         'numpy >= 1.26.0',
-        'qocogen >= 0.1.6',
+        'qocogen >= 0.1.9',
         'qoco >= 0.1.4'
     ],
     extras_require={


### PR DESCRIPTION
This PR fixes issue https://github.com/cvxgrp/cvxpygen/issues/69. 

Previously qocogen did not even generate a license file, which is why we must bump qocogen to v0.1.9.