### PR TITLE
Allow a subset of the variables to be stored/computed explicitly

### DIFF
--- a/cvxpygen/mappings.py
+++ b/cvxpygen/mappings.py
@@ -74,6 +74,7 @@ class VariableInfo:
 class PrimalVariableInfo(VariableInfo):
     name_to_sym: Dict[str, bool]
     sym: List[bool]
+    reduced: bool = False
 
 
 @dataclass

--- a/cvxpygen/mpqp.py
+++ b/cvxpygen/mpqp.py
@@ -104,7 +104,6 @@ def offline_solve_and_codegen_explicit(problem, canon, solver_code_dir, solver_o
             canon.prim_variable_info.name_to_offset[name] = shift
             canon.prim_variable_info.name_to_indices[name] = np.full(size,-1)
             canon.prim_variable_info.name_to_indices[name][inds] = np.arange(0,len(inds))
-            canon.prim_variable_info.name_to_init[name][:] = np.nan
             added_names.append(name)
             shift+=len(inds)
         #else:

--- a/cvxpygen/mpqp.py
+++ b/cvxpygen/mpqp.py
@@ -86,7 +86,7 @@ def offline_solve_and_codegen_explicit(problem, canon, solver_code_dir, solver_o
 
     # extract variables to store
     all_names = [name for name in canon.prim_variable_info.name_to_offset]
-    stored_vars = solver_opts.get('stored_vars', all_names) if solver_opts else None
+    stored_vars = solver_opts.get('stored_vars', None) if solver_opts else None
     names_and_inds = []
     if stored_vars is not None:
         for s in stored_vars:

--- a/cvxpygen/mpqp.py
+++ b/cvxpygen/mpqp.py
@@ -103,7 +103,7 @@ def offline_solve_and_codegen_explicit(problem, canon, solver_code_dir, solver_o
 
             canon.prim_variable_info.name_to_offset[name] = shift
             canon.prim_variable_info.name_to_indices[name] = np.full(size,-1)
-            canon.prim_variable_info.name_to_indices[name][inds] = shift+np.arange(0,len(inds))
+            canon.prim_variable_info.name_to_indices[name][inds] = np.arange(0,len(inds))
             canon.prim_variable_info.name_to_init[name][:] = np.nan
             added_names.append(name)
             shift+=len(inds)

--- a/cvxpygen/mpqp.py
+++ b/cvxpygen/mpqp.py
@@ -95,7 +95,7 @@ def offline_solve_and_codegen_explicit(problem, canon, solver_code_dir, solver_o
     for var,inds in stored_vars:
         name = str(var)
         offset = canon.prim_variable_info.name_to_offset.get(name,None)
-        if offset:
+        if offset is not None:
             size = canon.prim_variable_info.name_to_size[name]
             inds = np.array(inds,dtype='int') if inds else np.arange(0,size)
 

--- a/cvxpygen/mpqp.py
+++ b/cvxpygen/mpqp.py
@@ -89,8 +89,6 @@ def offline_solve_and_codegen_explicit(problem, canon, solver_code_dir, solver_o
     stored_vars = solver_opts.get('stored_vars', all_names) if solver_opts else all_names
     stored_vars = [var if len(var)==2 else (var,None) for var in stored_vars]
 
-    print(canon.prim_variable_info)
-
     shift=0
     added_names = []
     for var,inds in stored_vars:
@@ -126,7 +124,6 @@ def offline_solve_and_codegen_explicit(problem, canon, solver_code_dir, solver_o
             del canon.prim_variable_info.sym[i]
             canon.prim_variable_info.reduced = True
 
-    print(canon.prim_variable_info)
     # construct explicit solution
     mpqp = MPQP(H, f, F, A, b, B, thmin, thmax, eq_inds=eq_inds, out_inds=out_inds)
     mpqp.solve(settings={'region_limit': max_regions, 'store_dual': (explicit_flag==2)})

--- a/cvxpygen/mpqp.py
+++ b/cvxpygen/mpqp.py
@@ -121,6 +121,7 @@ def offline_solve_and_codegen_explicit(problem, canon, solver_code_dir, solver_o
             del canon.prim_variable_info.name_to_sym[name]
             del canon.prim_variable_info.sizes[i]
             del canon.prim_variable_info.sym[i]
+            canon.prim_variable_info.reduced = True
 
     # construct explicit solution
     mpqp = MPQP(H, f, F, A, b, B, thmin, thmax, eq_inds=eq_inds, out_inds=out_inds)

--- a/cvxpygen/mpqp.py
+++ b/cvxpygen/mpqp.py
@@ -98,7 +98,7 @@ def offline_solve_and_codegen_explicit(problem, canon, solver_code_dir, solver_o
                 sl = [ku.format_slice(key,sh,len(v.shape)) if not ku.is_special_slice(key) else key
                               for key,sh in zip(sl[0],v.shape)]
                 ranges = [np.arange(s.start,s.stop,s.step) if type(s) == slice else s for s in sl]
-                inds = [np.ravel_multi_index(id, v.shape) for id in product(*ranges)]
+                inds = [np.ravel_multi_index(id, v.shape,order='F') for id in product(*ranges)]
                 names_and_inds.append((v.name(), inds))
     else: # by default, store all variables
         for name in all_names: names_and_inds.append((name,None))

--- a/cvxpygen/mpqp.py
+++ b/cvxpygen/mpqp.py
@@ -19,6 +19,7 @@ import cvxpy as cp
 from scipy import sparse
 from pdaqp import MPQP
 from itertools import product
+from cvxpy.utilities import key_utils as ku
 
 
 def offline_solve_and_codegen_explicit(problem, canon, solver_code_dir, solver_opts, explicit_flag):
@@ -94,7 +95,9 @@ def offline_solve_and_codegen_explicit(problem, canon, solver_code_dir, solver_o
             if sl is None: # Variable => store all
                 names_and_inds.append((v.name(), None))
             else:
-                ranges = [np.arange(s.start,s.stop,s.step) for s in sl[0]]
+                sl = [ku.format_slice(key,sh,len(v.shape)) if not ku.is_special_slice(key) else key
+                              for key,sh in zip(sl[0],v.shape)]
+                ranges = [np.arange(s.start,s.stop,s.step) if type(s) == slice else s for s in sl]
                 inds = [np.ravel_multi_index(id, v.shape) for id in product(*ranges)]
                 names_and_inds.append((v.name(), inds))
     else: # by default, store all variables

--- a/cvxpygen/mpqp.py
+++ b/cvxpygen/mpqp.py
@@ -89,6 +89,7 @@ def offline_solve_and_codegen_explicit(problem, canon, solver_code_dir, solver_o
     stored_vars = solver_opts.get('stored_vars', all_names) if solver_opts else all_names
     stored_vars = [var if len(var)==2 else (var,None) for var in stored_vars]
 
+    print(canon.prim_variable_info)
 
     shift=0
     added_names = []
@@ -102,8 +103,11 @@ def offline_solve_and_codegen_explicit(problem, canon, solver_code_dir, solver_o
             out_inds = np.append(out_inds, offset+inds)
 
             canon.prim_variable_info.name_to_offset[name] = shift
-            canon.prim_variable_info.name_to_indices[name] = np.full(size,-1)
-            canon.prim_variable_info.name_to_indices[name][inds] = np.arange(0,len(inds))
+            if size == 1:
+                canon.prim_variable_info.name_to_indices[name] = np.array([shift])
+            else:
+                canon.prim_variable_info.name_to_indices[name] = np.full(size,-1)
+                canon.prim_variable_info.name_to_indices[name][inds] = np.arange(0,len(inds))
             added_names.append(name)
             shift+=len(inds)
         #else:
@@ -122,6 +126,7 @@ def offline_solve_and_codegen_explicit(problem, canon, solver_code_dir, solver_o
             del canon.prim_variable_info.sym[i]
             canon.prim_variable_info.reduced = True
 
+    print(canon.prim_variable_info)
     # construct explicit solution
     mpqp = MPQP(H, f, F, A, b, B, thmin, thmax, eq_inds=eq_inds, out_inds=out_inds)
     mpqp.solve(settings={'region_limit': max_regions, 'store_dual': (explicit_flag==2)})

--- a/cvxpygen/utils.py
+++ b/cvxpygen/utils.py
@@ -1192,8 +1192,6 @@ def write_solve_def(f, configuration, variable_info, dual_variable_info, paramet
             f.write('  }\n')
             f.write(f'  return obj_val;\n')
             f.write('}\n\n')
-        else:
-            f.write(f'cpg_float {configuration.prefix}cpg_obj(){{obj_val = 1e30; return obj_val;}};\n')
 
 
 
@@ -1260,8 +1258,9 @@ def write_solve_prot(f, configuration, variable_info, dual_variable_info, parame
     f.write(f'extern void {configuration.prefix}cpg_solve();\n')
     
     if configuration.explicit:
-        f.write('\n// Compute value of the objective\n')
-        f.write(f'extern cpg_float {configuration.prefix}cpg_obj();\n')
+        if not variable_info.reduced:
+            f.write('\n// Compute value of the objective\n')
+            f.write(f'extern cpg_float {configuration.prefix}cpg_obj();\n')
 
     if not configuration.explicit:  # TODO: explicit case
         f.write('\n// Update solver settings\n')

--- a/cvxpygen/utils.py
+++ b/cvxpygen/utils.py
@@ -1430,9 +1430,14 @@ def write_module_def(f, configuration, variable_info, dual_variable_info, parame
         if is_mathematical_scalar(var):
             f.write(f'    CPG_Prim_cpp.{name} = {configuration.prefix}CPG_Prim.{name};\n')
         else:
-            f.write(f'    for(i=0; i<{var.size}; i++) {{\n')
-            f.write(f'        CPG_Prim_cpp.{name}[i] = {configuration.prefix}CPG_Prim.{name}[i];\n')
-            f.write('    }\n')
+            if configuration.explicit:
+                for i, idx in enumerate(variable_info.name_to_indices[name]):
+                    if idx >= 0:
+                        f.write(f'    CPG_Prim_cpp.{name}[%d] = {configuration.prefix}CPG_Prim.{name}[%d];\n' % (i,idx))
+            else:
+                f.write(f'    for(i=0; i<{var.size}; i++) {{\n')
+                f.write(f'        CPG_Prim_cpp.{name}[i] = {configuration.prefix}CPG_Prim.{name}[i];\n')
+                f.write('    }\n')
 
     if configuration.explicit != 1:
         if len(dual_variable_info.name_to_init) > 0:

--- a/cvxpygen/utils.py
+++ b/cvxpygen/utils.py
@@ -586,7 +586,10 @@ def write_workspace_def(f, configuration, variable_info, dual_variable_info, par
                 
     if configuration.explicit:
         write_vec_def(f, np.zeros(parameter_canon.n_param_reduced), f'{configuration.prefix}cpg_theta', 'cpg_float')
-        write_vec_def(f, np.zeros(sum(variable_info.sizes)), 'sol_x', 'cpg_float')
+        if variable_info.reduced:
+            write_vec_def(f, np.zeros(sum(variable_info.sizes)), 'sol_x', 'cpg_float')
+        else:
+            write_vec_def(f, np.zeros(solver_interface.n_var), 'sol_x', 'cpg_float')
     if configuration.explicit == 2:
         write_vec_def(f, np.zeros(parameter_canon.n_dual_reduced), 'sol_y', 'cpg_float')
 
@@ -910,7 +913,10 @@ def write_workspace_prot(f, configuration, variable_info, dual_variable_info, pa
                 
     if configuration.explicit:
         write_vec_prot(f, np.zeros(parameter_canon.n_param_reduced), f'{prefix}cpg_theta', 'cpg_float')
-        write_vec_prot(f, np.zeros(sum(variable_info.sizes)), 'sol_x', 'cpg_float')
+        if variable_info.reduced:
+            write_vec_prot(f, np.zeros(sum(variable_info.sizes)), 'sol_x', 'cpg_float')
+        else:
+            write_vec_prot(f, np.zeros(solver_interface.n_var), 'sol_x', 'cpg_float')
     if configuration.explicit == 2:
         write_vec_prot(f, np.zeros(parameter_canon.n_dual_reduced), 'sol_y', 'cpg_float')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "numpy >= 1.26.0",
   "qocogen >= 0.1.9",
   "qoco >= 0.1.4",
-  "pdaqp >= 0.6.5"
+  "pdaqp >= 0.6.6"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "numpy >= 1.26.0",
   "qocogen >= 0.1.9",
   "qoco >= 0.1.4",
-  "pdaqp >= 0.6.4"
+  "pdaqp >= 0.6.5"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR adds support for only storing/computing a subset of the variables explicitly. This is, for example, very useful in the context of MPC, where only the optimal control at the first time step needs to be stored.

The user chooses which variables to store through the field `stored_vars` in `solver_opts`, which is a list of cvxpy variables. If `stored_vars` is not set, all variables will be stored/computed explicitly.

As an example, if the cvxpy Variable `U` should be stored explicitly, the user sets

``` python
solver_opts = {'stored_vars': [U]}
```

If the user only  wants the first and second elements of `U, the user can use:
``` python
solver_opts = {'stored_vars': [U[0:1]]}
```
The "normal" cvxpy indexing can be used if U is an ndarray.

In addition, this PR removes some superfluous data from the canonicalization that is not needed for explicit solvers.

