### PR TITLE
support use of cp.SOC

### DIFF
--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -5,10 +5,11 @@ import numpy as np
 def get_dual_vec(prob):
     dual_values = []
     for constr in prob.constraints:
-        if constr.args[0].size == 1:
-            dual_values.append(np.atleast_1d(constr.dual_value).flatten())
+        if type(constr.dual_value) == list and type(constr.dual_value[0]) == np.ndarray:
+            for dv in constr.dual_value:
+                dual_values.append(np.atleast_1d(dv).flatten())
         else:
-            dual_values.append(constr.dual_value.flatten())
+            dual_values.append(np.atleast_1d(constr.dual_value).flatten())
     return np.concatenate(dual_values)
 
 


### PR DESCRIPTION
Previously, only constraints where the number of dual variables equals the shape of the constraint were supported. This PR introduces support for more general constraints, like those modeled with `cp.SOC`. Addressing #83.