### PR TITLE
Replace `pickle` with `dill` for serialization

### DIFF
--- a/cvxpygen/cpg.py
+++ b/cvxpygen/cpg.py
@@ -14,7 +14,7 @@ limitations under the License.
 import os
 import sys
 import shutil
-import pickle
+import dill as pickle
 import warnings
 import copy
 import importlib

--- a/cvxpygen/template/README.html
+++ b/cvxpygen/template/README.html
@@ -147,7 +147,7 @@ $CPGSETTINGSDECLARATIONS
       To use the CVXPY interface, run exemplarily,
   </p>
     <pre><code>
-import pickle
+import dill as pickle
 from $CDPYTHON.cpg_solver import cpg_solve
 
 with open('$CODEDIR/problem.pickle', 'rb') as f:

--- a/examples/ADP.ipynb
+++ b/examples/ADP.ipynb
@@ -135,7 +135,7 @@
    "source": [
     "from ADP_code.cpg_solver import cpg_solve\n",
     "import numpy as np\n",
-    "import pickle\n",
+    "import dill as pickle\n",
     "import time\n",
     "\n",
     "# load the serialized problem formulation\n",

--- a/examples/MPC.ipynb
+++ b/examples/MPC.ipynb
@@ -141,7 +141,7 @@
    "source": [
     "from MPC_code.cpg_solver import cpg_solve\n",
     "import numpy as np\n",
-    "import pickle\n",
+    "import dill as pickle\n",
     "import time\n",
     "\n",
     "# load the serialized problem formulation\n",

--- a/examples/actuator.ipynb
+++ b/examples/actuator.ipynb
@@ -128,7 +128,7 @@
    "source": [
     "from actuator_code.cpg_solver import cpg_solve\n",
     "import numpy as np\n",
-    "import pickle\n",
+    "import dill as pickle\n",
     "import time\n",
     "\n",
     "# load the serialized problem formulation\n",

--- a/examples/charging.ipynb
+++ b/examples/charging.ipynb
@@ -155,7 +155,7 @@
    "source": [
     "from charging_code.cpg_solver import cpg_solve\n",
     "import numpy as np\n",
-    "import pickle\n",
+    "import dill as pickle\n",
     "import time\n",
     "\n",
     "# load the serialized problem formulation\n",

--- a/examples/network.ipynb
+++ b/examples/network.ipynb
@@ -124,7 +124,7 @@
    "source": [
     "from network_code.cpg_solver import cpg_solve\n",
     "import numpy as np\n",
-    "import pickle\n",
+    "import dill as pickle\n",
     "import time\n",
     "\n",
     "# load the serialized problem formulation\n",

--- a/examples/portfolio.ipynb
+++ b/examples/portfolio.ipynb
@@ -159,7 +159,7 @@
    "source": [
     "from portfolio_code.cpg_solver import cpg_solve\n",
     "import numpy as np\n",
-    "import pickle\n",
+    "import dill as pickle\n",
     "import time\n",
     "\n",
     "# load the serialized problem formulation\n",

--- a/examples/resource.ipynb
+++ b/examples/resource.ipynb
@@ -111,7 +111,7 @@
    "source": [
     "from resource_code.cpg_solver import cpg_solve\n",
     "import numpy as np\n",
-    "import pickle\n",
+    "import dill as pickle\n",
     "import time\n",
     "\n",
     "# load the serialized problem formulation\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
   "numpy >= 1.26.0",
   "qocogen >= 0.1.9",
   "qoco >= 0.1.4",
-  "pdaqp >= 0.6.6"
+  "pdaqp >= 0.6.6",
+  "dill>=0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_E2E_LP.py
+++ b/tests/test_E2E_LP.py
@@ -6,7 +6,7 @@ import glob
 import os
 import importlib
 import itertools
-import pickle
+import dill as pickle
 import utils_test
 import sys
 sys.path.append('../')

--- a/tests/test_E2E_QP.py
+++ b/tests/test_E2E_QP.py
@@ -7,7 +7,7 @@ import os
 import io
 import importlib
 import itertools
-import pickle
+import dill as pickle
 import utils_test
 import sys
 sys.path.append('../')

--- a/tests/test_E2E_SOCP.py
+++ b/tests/test_E2E_SOCP.py
@@ -6,7 +6,7 @@ import glob
 import os
 import importlib
 import itertools
-import pickle
+import dill as pickle
 import utils_test
 import sys
 sys.path.append('../')


### PR DESCRIPTION
This replaces the python `pickling` module with the more robust `dill` (see [dill](https://github.com/uqfoundation/dill)), which is used by many projects that require serialization.

This will fix the serialization part of issue #72 and prevent more serialization issues in the future.

Models of this form will no longer fail to serialize:
```python
import cvxpy as cp
import numpy as np
from cvxpygen import cpg
import dill as pickle

# setup model
m, n = 3, 2
x = cp.Variable(n, name="x")
A = cp.Parameter((m, n), name="A", sparsity=((0, 0, 1), (0, 1, 1)))
b = cp.Parameter(m, name="b")
d = cp.Parameter(m, name="d")
bd = cp.CallbackParam(
    shape=(m,), callback=lambda: d.value * b.value, name="bd"
)
problem = cp.Problem(cp.Minimize(cp.sum_squares(A @ x - bd)), [x >= 0])

# set values for parameters
np.random.seed(0)
A.value = np.zeros((m, n))
A.value[0, 0] = np.random.randn()
A.value[0, 1] = np.random.randn()
A.value[1, 1] = np.random.randn()
b.value = np.random.randn(m)
d.value = np.random.randn(m)

# solve
problem.solve()
obj = problem.value
print("Objective value:", obj)

# code gen
cpg.generate_code(problem, code_dir="nonneg_LS", solver="SCS")

from nonneg_LS.cpg_solver import cpg_solve

with open('nonneg_LS/problem.pickle', 'rb') as f:
    prob = pickle.load(f)

prob.register_solve('CPG', cpg_solve)

obj = prob.solve(method='CPG')
print("Objective value:", obj)
```