### PR TITLE
Bump pdaqp to 0.6.7 to use patched version of juliacall

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "numpy >= 1.26.0",
   "qocogen >= 0.1.9",
   "qoco >= 0.1.4",
-  "pdaqp >= 0.6.6"
+  "pdaqp >= 0.6.7"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR updates the version of pdaqp, which uses the latest version of julicall (v0.9.26),  [this fix](https://github.com/JuliaPy/PythonCall.jl/commit/07eb7268125afac66738ded4ddd44d7cde5f0c50) is included.

This should most likely fix sporadic segfaults we have seen during CI, including #88. 