### PR TITLE
Use store transpose from pdaqp 0.7.1

### DIFF
--- a/cvxpygen/solvers/pdaqp.py
+++ b/cvxpygen/solvers/pdaqp.py
@@ -205,7 +205,9 @@ class PDAQPInterface(QPCanonMixin, SolverInterface):
         if str(mpqp.solution_info.status) != 'Solved':
             raise Exception(f'Could not compute explicit solution: {mpqp.solution_info.status}')
 
-        codegen_status = mpqp.codegen(dir=solver_code_dir, max_reals=max_floats, dual=store_dual, c_float_store=c_float_store)
+        codegen_status = mpqp.codegen(dir=solver_code_dir, max_reals=max_floats, dual=store_dual,
+                                      c_float_store=c_float_store, store_transpose=configuration.gradient,
+                                      store_offset=configuration.gradient)
         if codegen_status < 0:
             raise Exception('Could not generate explicit solver. Consider increasing max_reals in solver_opts.')
 
@@ -217,9 +219,6 @@ class PDAQPInterface(QPCanonMixin, SolverInterface):
         c_file = os.path.join(src_dir, 'pdaqp.c')
         shutil.move(os.path.join(solver_code_dir, 'pdaqp.h'), h_file)
         shutil.move(os.path.join(solver_code_dir, 'pdaqp.c'), c_file)
-
-        if configuration.gradient:
-            self._patch_pdaqp_for_gradient(h_file, c_file)
 
         # create solver_code_dir/CMakeLists.txt
         with open(os.path.join(solver_code_dir, 'CMakeLists.txt'), 'w') as fl:
@@ -233,32 +232,6 @@ class PDAQPInterface(QPCanonMixin, SolverInterface):
         canon.parameter_canon.n_dual_reduced = len(b)
         canon.parameter_info.lower = lower
         canon.parameter_info.upper = upper
-
-    @staticmethod
-    def _patch_pdaqp_for_gradient(h_file, c_file):
-        """Post-process generated pdaqp.c/h to expose the active critical region index."""
-
-        # header: expose the global and array symbols needed by gradient code
-        utils.read_write_file(h_file, lambda text: text.replace(
-            '#endif // ifndef PDAQP_H',
-            'extern int pdaqp_active_region;\n'
-            'extern c_float_store pdaqp_feedbacks[];\n'
-            'extern c_int pdaqp_hp_list[];\n'
-            '#endif // ifndef PDAQP_H',
-        ))
-        
-        # source: add global and record active region before the feedback evaluation
-        utils.read_write_file(c_file, lambda text: text
-            .replace(
-                'void pdaqp_evaluate(',
-                'int pdaqp_active_region = -1;\nvoid pdaqp_evaluate(',
-            )
-            .replace(
-                '    // Leaf node reached -> evaluate affine function\n',
-                '    // Leaf node reached -> evaluate affine function\n'
-                '    pdaqp_active_region = id;\n',
-            )
-        )
 
     @staticmethod
     def _get_parameter_delta_bounds(problem, canon):

--- a/cvxpygen/templates/cpg_module.hpp.jinja2
+++ b/cvxpygen/templates/cpg_module.hpp.jinja2
@@ -57,9 +57,7 @@ struct {{ prefix }}CPG_Info_cpp_t {
 {% endif %}
     double time;
 {% if gradient %}
-{% if explicit %}
-    int region;
-{% else %}
+{% if not explicit %}
     std::array<double, {{ n_grad_var }}> gradient_primal;
     std::array<double, {{ n_grad_constr }}> gradient_dual;
 {% endif %}
@@ -95,7 +93,7 @@ struct {{ prefix }}CPG_PDelta_cpp_t {
 
 // Derivative function
 {% if explicit %}
-{{ prefix }}CPG_PDelta_cpp_t {{ prefix }}gradient_cpp(struct {{ prefix }}CPG_VDelta_cpp_t& CPG_VDelta_cpp, int region, bool use_sol);
+{{ prefix }}CPG_PDelta_cpp_t {{ prefix }}gradient_cpp(struct {{ prefix }}CPG_VDelta_cpp_t& CPG_VDelta_cpp, bool use_sol);
 {% else %}
 {{ prefix }}CPG_PDelta_cpp_t {{ prefix }}gradient_cpp(struct {{ prefix }}CPG_VDelta_cpp_t& CPG_VDelta_cpp, struct {{ prefix }}CPG_GSol_cpp_t& CPG_GSol_cpp, bool use_sol);
 {% endif %}

--- a/cvxpygen/templates/cpg_solver.py.jinja2
+++ b/cvxpygen/templates/cpg_solver.py.jinja2
@@ -28,7 +28,7 @@ def get_param_value(param):
         return squeeze_scalar(param.value)
     elif param.attributes["diag"]:
         return list(np.diag(param.value))
-    elif param._has_dim_reducing_attr:
+    elif getattr(param, "_has_dim_reducing_attr", False):
         return list(param.value_sparse.data)
     else:
         return list(param.value.flatten(order="F"))
@@ -88,7 +88,7 @@ def cpg_solve(prob, updated_params=None, **kwargs):
 {% endif %}
 
 {% if explicit %}
-    return res.cpg_info.time{% if gradient %}, res.cpg_info.region{% endif %}
+    return res.cpg_info.time
 
 
 {% else %}
@@ -125,7 +125,7 @@ def cpg_solve(prob, updated_params=None, **kwargs):
 def cpg_solve(prob, updated_params=None, **kwargs):
 
 {% if explicit %}
-    val, _ = cpg_solve_and_gradient_info(prob, updated_params, **kwargs)
+    val = cpg_solve_and_gradient_info(prob, updated_params, **kwargs)
 {% else %}
     val, _, _ = cpg_solve_and_gradient_info(prob, updated_params, **kwargs)
 {% endif %}
@@ -133,18 +133,14 @@ def cpg_solve(prob, updated_params=None, **kwargs):
 
 
 {% if explicit %}
-def cpg_gradient(prob, region=None):
+def cpg_gradient(prob):
 {% else %}
 def cpg_gradient(prob, gradient_sol_primal=None, gradient_sol_dual=None):
 {% endif %}
 
     # set solution info if provided
 {% if explicit %}
-    if region is not None:
-        use_sol = True
-    else:
-        region = 0
-        use_sol = False
+    use_sol = False
 {% else %}
     gradient_sol = cpg_module.{{ prefix }}cpg_gsol()
     if gradient_sol_primal is not None and gradient_sol_dual is not None:
@@ -167,7 +163,7 @@ def cpg_gradient(prob, gradient_sol_primal=None, gradient_sol_dual=None):
 {% endif %}
 {% endfor %}
 {% if explicit %}
-    pdelta = cpg_module.gradient(vdelta, region, use_sol)
+    pdelta = cpg_module.gradient(vdelta, use_sol)
 {% else %}
     pdelta = cpg_module.gradient(vdelta, gradient_sol, use_sol)
 {% endif %}
@@ -186,7 +182,7 @@ def forward(params, context):
         next(p for p in parameters if p.id == pid).value = val
     updated_params = kwargs.pop("updated_params", None)
 {% if explicit %}
-    _, info["region"] = cpg_solve_and_gradient_info(prob, updated_params, **kwargs)
+    cpg_solve_and_gradient_info(prob, updated_params, **kwargs)
 {% else %}
     _, info["gradient_primal"], info["gradient_dual"] = cpg_solve_and_gradient_info(prob, updated_params, **kwargs)
 {% endif %}
@@ -203,8 +199,7 @@ def backward(dvars, context):
     for variable, dv in zip(context.variables, dvars):
         next(v for v in vars if v.id == variable.id).gradient = dv
 {% if explicit %}
-    region = context.info["region"]
-    cpg_gradient(prob, region)
+    cpg_gradient(prob)
 {% else %}
     gradient_primal = context.info["gradient_primal"]
     gradient_dual = context.info["gradient_dual"]

--- a/cvxpygen/utils.py
+++ b/cvxpygen/utils.py
@@ -1253,12 +1253,8 @@ def write_module_def(f, config, variable_info, dual_variable_info, parameter_inf
             f.write(f'    CPG_Info_cpp.{field} = {config.prefix}CPG_Info.{field};\n')
     f.write('    std::chrono::duration<double> elapsed = ASA_end - ASA_start;\n')
     f.write('    CPG_Info_cpp.time = elapsed.count();\n')
-    #else:
-    #    f.write('    CPG_Info_cpp.time = 1.0 * (ASA_end - ASA_start) / CLOCKS_PER_SEC / 1000;\n')
     if config.gradient:
-        if config.explicit:
-            f.write(f'    CPG_Info_cpp.region = pdaqp_active_region;\n')
-        else:
+        if not config.explicit:
             f.write(f'    for(i=0; i<{gradient_interface.n_var}; i++) {{\n')
             f.write(f'        CPG_Info_cpp.gradient_primal[i] = {f"gradient_{config.prefix}" if config.gradient_two_stage else ""}sol_x[i];\n')
             f.write('    }\n')
@@ -1282,7 +1278,7 @@ def write_module_def(f, config, variable_info, dual_variable_info, parameter_inf
         if config.explicit:
             f.write(f'{config.prefix}CPG_PDelta_cpp_t {config.prefix}gradient_cpp('
                     f'struct {config.prefix}CPG_VDelta_cpp_t& CPG_VDelta_cpp, '
-                    f'int region, bool use_sol){{\n\n')
+                    f'bool use_sol){{\n\n')
         else:
             f.write(f'{config.prefix}CPG_PDelta_cpp_t {config.prefix}gradient_cpp('
                     f'struct {config.prefix}CPG_VDelta_cpp_t& CPG_VDelta_cpp, '
@@ -1290,9 +1286,7 @@ def write_module_def(f, config, variable_info, dual_variable_info, parameter_inf
 
         f.write('    // Set solution in canonical form for gradient computation\n')
         f.write('    if (use_sol) {\n')
-        if config.explicit:
-            f.write(f'        pdaqp_active_region = region;\n')
-        else:
+        if not config.explicit:
             f.write(f'        for(i=0; i<{gradient_interface.n_var}; i++) {{\n')
             f.write(f'            {f"gradient_{config.prefix}" if config.gradient_two_stage else ""}sol_x[i] = CPG_GSol_cpp.primal[i];\n')
             f.write('        }\n')
@@ -1381,9 +1375,7 @@ def write_module_def(f, config, variable_info, dual_variable_info, parameter_inf
         f.write(f'            .def_readwrite("dua_res", &{config.prefix}CPG_Info_cpp_t::dua_res)\n')
     f.write(f'            .def_readwrite("time", &{config.prefix}CPG_Info_cpp_t::time)\n')
     if config.gradient:
-        if config.explicit:
-            f.write(f'            .def_readwrite("region", &{config.prefix}CPG_Info_cpp_t::region)\n')
-        else:
+        if not config.explicit:
             f.write(f'            .def_readwrite("gradient_primal", &{config.prefix}CPG_Info_cpp_t::gradient_primal)\n')
             f.write(f'            .def_readwrite("gradient_dual", &{config.prefix}CPG_Info_cpp_t::gradient_dual)\n')
     f.write('            ;\n\n')

--- a/cvxpygen/writer.py
+++ b/cvxpygen/writer.py
@@ -488,11 +488,13 @@ class CCodeWriter:
 
             # Canonical diff dtheta = Z_active[:, :n_params].T @ dx
             f.write('  // Step 1: dtheta = Z_active[:, :n_params].T @ dx\n')
-            f.write('  int base = pdaqp_hp_list[pdaqp_active_region] * (PDAQP_N_PARAMETER+1) * PDAQP_N_SOLUTION;\n')
+            f.write('  int base = pdaqp_feedback_offset;\n')
             f.write(f'  for(j=0; j<{n_params}; j++){{\n')
             f.write(f'    cpg_dtheta[j] = 0.0;\n')
             f.write(f'    for(i=0; i<{n_sol}; i++){{\n')
-            f.write(f'      cpg_dtheta[j] += (cpg_float)pdaqp_feedbacks[base + i*(PDAQP_N_PARAMETER+1) + j] * cpg_dx[i];\n')
+            f.write(f'      cpg_dtheta[j] += (cpg_float)pdaqp_feedbacks_T[base++] * cpg_dx[i];\n')
+            # XXX if transpose is not stored:
+            #f.write(f'      cpg_dtheta[j] += (cpg_float)pdaqp_feedbacks[base + i*(PDAQP_N_PARAMETER+1) + j] * cpg_dx[i];\n')
             f.write('    }\n')
             f.write('  }\n\n')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "numpy >= 1.26.0",
   "qocogen >= 0.1.9",
   "qoco >= 0.1.4",
-  "pdaqp == 0.6.7",
+  "pdaqp >= 0.7.1",
   "jinja2 >= 3.0"
 ]
 


### PR DESCRIPTION
This PR makes it possible for the gradient calculation to use the transpose of the feedbacks from `pdaqp`, improving the striding.
We do this by using two new features in `pdaqp` v0.7.1:
* `pdaqp` now exposes the integer `pdaqp_offset_feedback`, which can be used to locate which feedback was used for the last evaluted parameter.
* `pdaqp` now exposes `pdaqp_feedbacks` and `pdaqp_feedbacks_T`, which can be used in gradient computations.