### PR TITLE
Basic pre-solve for explicit solver generation

### DIFF
--- a/cvxpygen/canonicalizer.py
+++ b/cvxpygen/canonicalizer.py
@@ -141,7 +141,7 @@ class Canonicalizer:
                 (_, col) = fill_coefficient.nonzero()
                 var_name_to_indices[var_name] = offset + col
             else:
-                var_name_to_indices[var_name] = np.arange(offset, offset + np.prod(shape))
+                var_name_to_indices[var_name] = np.arange(offset, offset + np.prod(shape).astype(int))
         var_name_to_size = {var.name(): var.size for var in variables}
         var_name_to_shape = {var.name(): var.shape for var in variables}
         var_name_to_init = {}

--- a/cvxpygen/compiler.py
+++ b/cvxpygen/compiler.py
@@ -17,9 +17,10 @@ class PythonModuleCompiler:
     cpg_solve function with the CVXPY problem instance.
     """
 
-    def __init__(self, code_dir: str, problem: cp.Problem) -> None:
-        self.code_dir = code_dir
+    def __init__(self, problem: cp.Problem, code_dir: str) -> None:
         self.problem = problem
+        self.code_dir = code_dir
+        
 
     def compile(self) -> None:
         """Build and install the C extension via scikit-build-core."""

--- a/cvxpygen/generator.py
+++ b/cvxpygen/generator.py
@@ -22,6 +22,7 @@ from cvxpygen.canonicalizer import Canonicalizer
 from cvxpygen.writer import CCodeWriter
 from cvxpygen.compiler import PythonModuleCompiler
 from cvxpygen.mappings import Configuration
+from cvxpygen.presolver import PreSolver
 
 
 class Generator:
@@ -78,20 +79,23 @@ class Generator:
         self.config = self._build_config(code_dir, solver, gradient_two_stage, explicit)
 
         self._run_canonicalization(problem, solver, gradient_two_stage)
-        self._setup_folder(code_dir)
-        self._run_solver_code_generation(problem, code_dir, explicit)
-        self._run_code_writing(problem)
+        if explicit:
+            self._run_presolve()
+        self._run_folder_setup()
+        self._run_solver_code_generation()
+        self._run_canon_code_generation()
 
         sys.stdout.write('CVXPYgen finished generating code.\n')
 
         if wrapper:
-            self._run_compilation(code_dir, problem)
+            self._run_compilation(problem)
 
     # ── private pipeline stages ───────────────────────────────────────────────
 
-    def _setup_folder(self, code_dir: str) -> None:
+    def _run_folder_setup(self) -> None:
 
-        shutil.rmtree(code_dir, ignore_errors=True)
+        code_dir = self.config.code_dir
+        shutil.rmtree(self.config.code_dir, ignore_errors=True)
         os.mkdir(code_dir)
 
         os.makedirs(os.path.join(code_dir, 'c', 'src'))
@@ -116,9 +120,14 @@ class Generator:
             self.gradient_interface = self.solver_interface
             self.canon_gradient = self.canon
             self.canon_solver = self.canon
+            
+    def _run_presolve(self) -> None:
+        presolver = PreSolver()
+        presolver.solve(self.canon, self.solver_interface)
 
-    def _run_solver_code_generation(self, problem: cp.Problem, code_dir: str, explicit: int) -> None:
+    def _run_solver_code_generation(self) -> None:
         """Call solver_interface.generate_code() to write solver-specific C files."""
+        code_dir = self.config.code_dir
         cvxpygen_dir = os.path.dirname(os.path.realpath(__file__))
         solver_code_dir = os.path.join(code_dir, 'c', 'solver_code')
         osqp_code_dir = os.path.join(code_dir, 'c', 'osqp_code')
@@ -139,9 +148,8 @@ class Generator:
                 self.canon, self._gradient, cfg.prefix,
             )
 
-    def _run_code_writing(self, problem: cp.Problem) -> None:
+    def _run_canon_code_generation(self) -> None:
         writer = CCodeWriter(
-            problem=problem,
             configuration=self.config,
             canon=self.canon,
             solver_interface=self.solver_interface,
@@ -151,8 +159,8 @@ class Generator:
         )
         writer.write()
 
-    def _run_compilation(self, code_dir: str, problem: cp.Problem) -> None:
-        compiler = PythonModuleCompiler(code_dir=code_dir, problem=problem)
+    def _run_compilation(self, problem: cp.Problem) -> None:
+        compiler = PythonModuleCompiler(problem=problem, code_dir=self.config.code_dir)
         compiler.compile()
         compiler.register()
 

--- a/cvxpygen/presolver.py
+++ b/cvxpygen/presolver.py
@@ -77,7 +77,7 @@ class PreSolver:
         pc.p_id_to_size['u'] = len(pc.p['u'])
 
         # update index book-keeping for variable retrieval
-        new_ind = np.cumsum(col_mask) - 1
+        new_ind = np.cumsum(col_mask).astype(int) - 1
         for name in list(pvi.name_to_offset):
             pvi.name_to_offset[name] = new_ind[pvi.name_to_offset[name]]
             pvi.name_to_indices[name] = new_ind[pvi.name_to_indices[name]]

--- a/cvxpygen/presolver.py
+++ b/cvxpygen/presolver.py
@@ -1,0 +1,87 @@
+"""
+Copyright 2026 Maximilian Schaller and the CVXPYgen contributors
+Licensed under the Apache License, Version 2.0
+"""
+
+import numpy as np
+import scipy.sparse as sp
+from cvxpygen.mappings import Canon
+from cvxpygen.solvers._interface import SolverInterface
+
+
+class PreSolver:
+    """
+    Very basic presolver before explicit solver generation.
+    """
+
+    def __init__(self) -> None:
+        pass
+    
+    def solve(
+        self,
+        canon: Canon,
+        solver_interface: SolverInterface
+    ) -> None:
+        
+        # identify to-eliminate vars
+        pc = canon.parameter_canon
+        P = pc.p['P'].toarray()
+        q = pc.p['q']
+        A = pc.p['A'].toarray()
+        u = pc.p['u']
+        
+        # get indices of vars that do not appear in objective
+        not_in_obj = set(np.where(np.all(P == 0, axis=0) & (q == 0))[0])
+        
+        # get indices of user-defined vars (will not be eliminated)
+        pvi = canon.prim_variable_info
+        user_defined = set()
+        for name, offset in pvi.name_to_offset.items():
+            user_defined.update(range(offset, offset + pvi.name_to_size[name]))
+
+        # record to-eliminate vars (not in obj or user-defined, upper-bounded only by non-vars)
+        candidate_indices = not_in_obj - user_defined
+        to_eliminate = {}  # var_index: (coefficient, constraint_index)
+        for i in candidate_indices:
+            mask = (A[:, i] > 0)
+            if sum(mask) == 1:  # unclear how to handle multiple upper bounds in the parametrized setting
+                A_pos_coef = A[mask]
+                if np.all(A_pos_coef[:, :i] == 0) & np.all(A_pos_coef[:, i+1:] == 0):
+                    to_eliminate[i] = (A_pos_coef[0, i], np.where(mask)[0][0])
+        
+        # remove variables and respective constraints
+        m, n = A.shape
+        row_mask = np.ones(m, dtype=bool)
+        col_mask = np.ones(n, dtype=bool)
+        for i, (coef, constr_ind) in to_eliminate.items():
+            row_mask[constr_ind] = False
+            col_mask[i] = False
+            for k in range(m):
+                if k == constr_ind:
+                    continue
+                if A[k, i] != 0:
+                    ratio = A[k, i] / coef
+                    pc.p_id_to_mapping['u'][k] -= ratio * pc.p_id_to_mapping['u'][constr_ind]
+                    u[k] -= ratio * u[constr_ind]
+        
+        # update canonical parameters and mappings
+        pc.p['P'] = sp.csc_matrix(P[np.ix_(col_mask, col_mask)])
+        pc.p['q'] = q[col_mask]
+        pc.p['A'] = sp.csc_matrix(A[np.ix_(row_mask, col_mask)])
+        pc.p['u'] = u[row_mask]
+
+        pc.p_id_to_mapping['q'] = pc.p_id_to_mapping['q'][col_mask]
+        pc.p_id_to_mapping['u'] = pc.p_id_to_mapping['u'][row_mask]
+
+        pc.p_id_to_size['q'] = len(pc.p['q'])
+        pc.p_id_to_size['u'] = len(pc.p['u'])
+
+        # update index book-keeping for variable retrieval
+        new_ind = np.cumsum(col_mask) - 1
+        for name in list(pvi.name_to_offset):
+            pvi.name_to_offset[name] = new_ind[pvi.name_to_offset[name]]
+            pvi.name_to_indices[name] = new_ind[pvi.name_to_indices[name]]
+             
+        # update solver interface   
+        solver_interface.n_var = pc.p_id_to_size['q']
+        solver_interface.n_ineq -= len(to_eliminate)

--- a/cvxpygen/presolver.py
+++ b/cvxpygen/presolver.py
@@ -23,8 +23,12 @@ class PreSolver:
         solver_interface: SolverInterface
     ) -> None:
         
-        # identify to-eliminate vars
+        # check that P and A are constants
         pc = canon.parameter_canon
+        if pc.p_id_to_changes['P'] or pc.p_id_to_changes['A']:
+            raise ValueError(f'Explicit solver generation: Matrices must be constant!')
+        
+        # identify to-eliminate vars
         P = pc.p['P'].toarray()
         q = pc.p['q']
         A = pc.p['A'].toarray()
@@ -76,12 +80,20 @@ class PreSolver:
         pc.p_id_to_size['q'] = len(pc.p['q'])
         pc.p_id_to_size['u'] = len(pc.p['u'])
 
-        # update index book-keeping for variable retrieval
-        new_ind = np.cumsum(col_mask).astype(int) - 1
+        # index book-keeping for primal variable retrieval
+        new_cols = np.cumsum(col_mask) - 1
         for name in list(pvi.name_to_offset):
-            pvi.name_to_offset[name] = new_ind[pvi.name_to_offset[name]]
-            pvi.name_to_indices[name] = new_ind[pvi.name_to_indices[name]]
-             
+            pvi.name_to_offset[name] = new_cols[pvi.name_to_offset[name]]
+            pvi.name_to_indices[name] = new_cols[pvi.name_to_indices[name]]
+
+        # index book-keeping for dual variable retrieval
+        dvi = canon.dual_variable_info
+        new_rows = np.cumsum(row_mask) - 1
+        for name in list(dvi.name_to_offset):
+            dvi.name_to_offset[name] = new_rows[dvi.name_to_offset[name]]
+            vec, old_indices = dvi.name_to_indices[name]
+            dvi.name_to_indices[name] = (vec, new_rows[old_indices])
+
         # update solver interface   
         solver_interface.n_var = pc.p_id_to_size['q']
         solver_interface.n_ineq -= len(to_eliminate)

--- a/cvxpygen/solvers/pdaqp.py
+++ b/cvxpygen/solvers/pdaqp.py
@@ -87,11 +87,6 @@ class PDAQPInterface(QPCanonMixin, SolverInterface):
         # set precision for storing explicit solution
         c_float_store = '_Float16' if self._solver_opts and (self._solver_opts.get('fp16', False) or self._solver_opts.get('FP16', False)) else 'float'
 
-        # check that P and A are constants
-        for p_id in ['P', 'A']:
-            if canon.parameter_canon.p_id_to_changes[p_id]:
-                raise ValueError(f'Explicit mode: Matrices must be constant!')
-
         A = canon.parameter_canon.p['A'].toarray()
         m, n = A.shape
 
@@ -111,6 +106,14 @@ class PDAQPInterface(QPCanonMixin, SolverInterface):
 
         # extract bounds on theta (thmin, thmax) and user-defined params (lower, upper)
         thmin, thmax, lower, upper = self._get_parameter_delta_bounds(self._problem, canon)
+
+        # remap dual variable indices from canonical row space to sol_y row space
+        row_remap = np.cumsum(A_mask) - 1  # canonical_row -> sol_y_row
+        dvi = canon.dual_variable_info
+        for name in list(dvi.name_to_offset):
+            dvi.name_to_offset[name] = row_remap[dvi.name_to_offset[name]]
+            vec, old_indices = dvi.name_to_indices[name]
+            dvi.name_to_indices[name] = (vec, row_remap[old_indices])
 
         # eliminate theta components that are fixed
         th_mask = (thmin != thmax)

--- a/cvxpygen/templates/cpg_solver.py.jinja2
+++ b/cvxpygen/templates/cpg_solver.py.jinja2
@@ -30,7 +30,7 @@ def get_param_value(param):
         return squeeze_scalar(param.value)
     elif param.attributes["diag"]:
         return list(np.diag(param.value))
-    elif param._has_dim_reducing_attr:
+    elif getattr(param, '_has_dim_reducing_attr', False):
         return list(param.value_sparse.data)
     else:
         return list(param.value.flatten(order="F"))

--- a/cvxpygen/utils.py
+++ b/cvxpygen/utils.py
@@ -769,10 +769,10 @@ def write_workspace_prot(f, config, variable_info, dual_variable_info, parameter
             f.write('typedef struct {\n')
             for name, size in dual_variable_info.name_to_size.items():
                 if size == 1:
-                    s = ''
+                    decl = f'{name};'
                 else:
-                    s = '*'
-                f.write(f'  cpg_float    {(s + name + ";").ljust(9)}   // Your dual variable for constraint {name}\n')
+                    decl = f'*{name};'
+                f.write(f'  cpg_float    {decl.ljust(9)}   // Your dual variable for constraint {name}\n')
             f.write('} CPG_Dual_t;\n\n')
 
         if not config.explicit:
@@ -1586,9 +1586,10 @@ def solver_py_context(config, variable_info, dual_variable_info, parameter_info,
 
     dual_save_list = []
     if config.explicit != 1:
-        for i, (name, shape) in enumerate(dual_variable_info.name_to_shape.items()):
+        for name, shape in dual_variable_info.name_to_shape.items():
+            constraint_idx = int(name[1:])  # d0 -> 0, d4 -> 4, etc.
             reshape_str = f".reshape({shape}, order='F')" if shape else ''
-            dual_save_list.append((i, name, shape, reshape_str))
+            dual_save_list.append((constraint_idx, name, shape, reshape_str))
 
     ctx = {
         'date': datetime.now().strftime("on %B %d, %Y at %H:%M:%S"),

--- a/cvxpygen/writer.py
+++ b/cvxpygen/writer.py
@@ -26,7 +26,6 @@ class CCodeWriter:
 
     def __init__(
         self,
-        problem: cp.Problem,
         configuration: Configuration,
         canon: Canon,
         solver_interface,
@@ -34,7 +33,6 @@ class CCodeWriter:
         canon_solver: Optional[Canon] = None,
         canon_gradient: Optional[Canon] = None,
     ) -> None:
-        self.problem = problem
         self.configuration = configuration
         self.canon = canon
         self.solver_interface = solver_interface

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -22,7 +22,7 @@ def test_gradient(n, solver):
     chol = np.random.randn(n, n)
     Q = chol @ chol.T / 10 + np.eye(n)
     b = cp.Parameter(n, name='b')
-    constr = [x >= 0]
+    constr = [cp.abs(x) <= 0.2]
     if solver == 'explicit':
         constr += [-1 <= b, b <= 1]
     obj = cp.Minimize(b @ x + cp.quad_form(x, Q))
@@ -49,7 +49,7 @@ def test_gradient(n, solver):
     prob.backward()
     g_cvxpy = b.gradient
 
-    assert np.allclose(g_cpg, g_cvxpy)
+    assert np.allclose(g_cpg, g_cvxpy, atol=1e-4)
     
     
 @pytest.mark.parametrize("n, solver", [(5, 'OSQP'), (5, 'explicit')])
@@ -57,7 +57,7 @@ def test_torch_sim(n, solver):
     
     np.random.seed(0)
     
-    # parametrized nonneg LS problem
+    # parametrized problem
     x = cp.Variable(n, name='x')
     xhat = cp.Parameter(n, name='xhat')
     b = cp.Parameter(n, name='b')

--- a/tests/test_explicit.py
+++ b/tests/test_explicit.py
@@ -1,5 +1,6 @@
 
 import pytest
+import importlib
 import cvxpy as cp
 import numpy as np
 import scipy.linalg as la
@@ -21,9 +22,10 @@ def test_regression():
     problem = cp.Problem(cp.Minimize(obj), constr)
 
     # generate code
-    cpg.generate_code(problem, code_dir='explicit_regression', solver='explicit', prefix='ex_regression')
-    from explicit_regression.cpg_solver import cpg_solve
-    problem.register_solve('cpg_explicit', cpg_solve)
+    identifier = 'explicit_regression'
+    cpg.generate_code(problem, code_dir=identifier, prefix=identifier, solver='explicit')
+    mod = importlib.import_module(f'{identifier}.cpg_solver')
+    problem.register_solve('cpg_explicit', mod.cpg_solve)
     
     np.random.seed(2)
 
@@ -74,9 +76,10 @@ def test_power():
     problem = cp.Problem(cp.Minimize(obj), constr)
 
     # generate code
-    cpg.generate_code(problem, code_dir='explicit_power', solver='explicit', prefix='ex_power')
-    from explicit_power.cpg_solver import cpg_solve
-    problem.register_solve('cpg_explicit', cpg_solve)
+    identifier = 'explicit_power'
+    cpg.generate_code(problem, code_dir=identifier, prefix=identifier, solver='explicit')
+    mod = importlib.import_module(f'{identifier}.cpg_solver')
+    problem.register_solve('cpg_explicit', mod.cpg_solve)
 
     np.random.seed(2)
 
@@ -141,12 +144,13 @@ def test_control(constr_type, capsys):
     problem = cp.Problem(cp.Minimize(obj), constr)
     
     # generate code
-    cpg.generate_code(problem, code_dir='explicit_MPC', solver='explicit', prefix='ex_mpc')
+    identifier = f'explicit_control_{constr_type}'
+    cpg.generate_code(problem, code_dir=identifier, prefix=identifier, solver='explicit')
     captured = capsys.readouterr()
     assert '10 linear inequality constraints' in captured.out
     
-    from explicit_MPC.cpg_solver import cpg_solve
-    problem.register_solve('cpg_explicit', cpg_solve)
+    mod = importlib.import_module(f'{identifier}.cpg_solver')
+    problem.register_solve('cpg_explicit', mod.cpg_solve)
 
     np.random.seed(2)
     
@@ -198,9 +202,10 @@ def test_control_fp16():
     problem = cp.Problem(cp.Minimize(obj), constr)
     
     # generate code
-    cpg.generate_code(problem, code_dir='explicit_MPC_fp16', solver='explicit', solver_opts={'fp16': True}, prefix='ex_mpc_fp16')
-    from explicit_MPC_fp16.cpg_solver import cpg_solve
-    problem.register_solve('cpg_explicit', cpg_solve)
+    identifier = 'explicit_control_fp16'
+    cpg.generate_code(problem, code_dir=identifier, prefix=identifier, solver='explicit', solver_opts={'fp16': True})
+    mod = importlib.import_module(f'{identifier}.cpg_solver')
+    problem.register_solve('cpg_explicit', mod.cpg_solve)
 
     np.random.seed(2)
     
@@ -244,19 +249,19 @@ def test_control_reduced():
     obj = cp.quad_form(X[:, H], P) + cp.sum_squares(X[:, :-1]) + 0.1 * cp.sum_squares(U)
     constr = [
         X[:, 1:] == A @ X[:, :-1] + B @ U,
-        -1 <= U, U <= 1,  # TODO: Test use of cp.norm and cp.abs
+        -1 <= U, U <= 1,
         X[:, 0] == xinit,
         -1 <= xinit, xinit <= 1
     ]
 
     problem = cp.Problem(cp.Minimize(obj), constr)
 
-    solver_opts= {"stored_vars":[U[:,0],X[[1,2],:]]}
     # generate code
-    cpg.generate_code(problem, code_dir='explicit_MPC_reduced', solver='explicit', prefix='ex_mpc_red',
-                      solver_opts=solver_opts)
-    from explicit_MPC_reduced.cpg_solver import cpg_solve
-    problem.register_solve('cpg_explicit', cpg_solve)
+    identifier = 'explicit_control_reduced'
+    cpg.generate_code(problem, code_dir=identifier, prefix=identifier, solver='explicit',
+                      solver_opts={"stored_vars":[U[:,0],X[[1,2],:]]})
+    mod = importlib.import_module(f'{identifier}.cpg_solver')
+    problem.register_solve('cpg_explicit', mod.cpg_solve)
 
     np.random.seed(2)
 
@@ -265,7 +270,6 @@ def test_control_reduced():
     problem.solve(solver='OSQP')
     X_ref = X.value
     U_ref = U.value
-    obj_ref = obj.value
 
     problem.solve(method='cpg_explicit')
     rtol = 1e-4
@@ -290,13 +294,17 @@ def test_stored_vars():
     problem = cp.Problem(cp.Minimize(obj), constr)
 
     # generate code
-    cpg.generate_code(problem, code_dir='ex_store_X', solver='explicit', prefix='ex_store_X', solver_opts = {'stored_vars':[X[0,:,[1]]]})
-    from ex_store_X.cpg_solver import cpg_solve
-    problem.register_solve('cpg_explicit_X', cpg_solve)
+    identifier = 'explicit_stored_vars_X'
+    cpg.generate_code(problem, code_dir=identifier, prefix=identifier, solver='explicit',
+                      solver_opts = {'stored_vars':[X[0,:,[1]]]})
+    mod = importlib.import_module(f'{identifier}.cpg_solver')
+    problem.register_solve('cpg_explicit_X', mod.cpg_solve)
 
-    cpg.generate_code(problem, code_dir='ex_store_xs', solver='explicit', prefix='ex_store_xs', solver_opts = {'stored_vars':[xs]})
-    from ex_store_xs.cpg_solver import cpg_solve
-    problem.register_solve('cpg_explicit_xs', cpg_solve)
+    identifier = 'explicit_stored_vars_xs'
+    cpg.generate_code(problem, code_dir=identifier, prefix=identifier, solver='explicit',
+                      solver_opts = {'stored_vars':[xs]})
+    mod = importlib.import_module(f'{identifier}.cpg_solver')
+    problem.register_solve('cpg_explicit_xs', mod.cpg_solve)
 
     np.random.seed(2)
 
@@ -339,12 +347,11 @@ def test_dual():
 
     problem = cp.Problem(cp.Minimize(obj), constr)
     
-    cpg.generate_code(problem, solver='explicit', solver_opts={'dual': True}, code_dir='explicit_dual', prefix='ex_dual')
-    
-    np.random.seed(0)
-    
-    from explicit_dual.cpg_solver import cpg_solve
-    problem.register_solve('gen_explicit', cpg_solve)
+    # generate code
+    identifier = 'explicit_dual'
+    cpg.generate_code(problem, code_dir=identifier, prefix=identifier, solver='explicit', solver_opts={'dual': True})    
+    mod = importlib.import_module(f'{identifier}.cpg_solver')
+    problem.register_solve('gen_explicit', mod.cpg_solve)
     
     y.value = [0.6, 0.8, 0.2]
     

--- a/tests/test_explicit.py
+++ b/tests/test_explicit.py
@@ -104,8 +104,11 @@ def test_power():
     assert np.allclose(obj.value, obj_ref, rtol=rtol)
 
 
-@pytest.mark.parametrize('constr_type', ['bounds', 'abs', 'norm'])
-def test_control(constr_type, capsys):
+@pytest.mark.parametrize(
+    'constr_type, compute_dual',
+    [('bounds', False), ('abs', False), ('norm', False), ('bounds', True), ('norm', True)]
+    )
+def test_control(constr_type, compute_dual, capsys):
     
     np.random.seed(1)
     
@@ -144,8 +147,9 @@ def test_control(constr_type, capsys):
     problem = cp.Problem(cp.Minimize(obj), constr)
     
     # generate code
-    identifier = f'explicit_control_{constr_type}'
-    cpg.generate_code(problem, code_dir=identifier, prefix=identifier, solver='explicit')
+    identifier = f'explicit_control_{constr_type}_{"dual" if compute_dual else "nodual"}'
+    cpg.generate_code(problem, code_dir=identifier, prefix=identifier, solver='explicit',
+                      solver_opts={'dual': compute_dual})
     captured = capsys.readouterr()
     assert '10 linear inequality constraints' in captured.out
     
@@ -160,12 +164,16 @@ def test_control(constr_type, capsys):
     X_ref = X.value
     U_ref = U.value
     obj_ref = obj.value
+    dual_ref = constr[-1].dual_value.copy()
     
     problem.solve(method='cpg_explicit')
     rtol = 1e-4
     assert np.allclose(X.value, X_ref, rtol=rtol)
     assert np.allclose(U.value, U_ref, rtol=rtol)
     assert np.allclose(obj.value, obj_ref, rtol=rtol)
+    
+    if compute_dual:
+        assert np.allclose(constr[-1].dual_value, dual_ref, rtol=rtol)
     
     
 def test_control_fp16():

--- a/tests/test_explicit.py
+++ b/tests/test_explicit.py
@@ -1,4 +1,5 @@
 
+import pytest
 import cvxpy as cp
 import numpy as np
 import scipy.linalg as la
@@ -100,7 +101,8 @@ def test_power():
     assert np.allclose(obj.value, obj_ref, rtol=rtol)
 
 
-def test_control():
+@pytest.mark.parametrize('constr_type', ['bounds', 'abs', 'norm'])
+def test_control(constr_type, capsys):
     
     np.random.seed(1)
     
@@ -126,15 +128,23 @@ def test_control():
     obj = cp.quad_form(X[:, H], P) + cp.sum_squares(X[:, :-1]) + 0.1 * cp.sum_squares(U)
     constr = [
         X[:, 1:] == A @ X[:, :-1] + B @ U,
-        -1 <= U, U <= 1,  # TODO: Test use of cp.norm and cp.abs
         X[:, 0] == xinit,
         -1 <= xinit, xinit <= 1
     ]
+    if constr_type == 'bounds':
+        constr += [-1 <= U, U <= 1]
+    elif constr_type == 'abs':
+        constr += [cp.abs(U) <= 1]
+    elif constr_type == 'norm':
+        constr += [cp.norm(U, 'inf', axis=0) <= 1]
 
     problem = cp.Problem(cp.Minimize(obj), constr)
     
     # generate code
     cpg.generate_code(problem, code_dir='explicit_MPC', solver='explicit', prefix='ex_mpc')
+    captured = capsys.readouterr()
+    assert '10 linear inequality constraints' in captured.out
+    
     from explicit_MPC.cpg_solver import cpg_solve
     problem.register_solve('cpg_explicit', cpg_solve)
 
@@ -345,7 +355,6 @@ def test_dual():
     obj_ref = obj.value
     
     problem.solve(method='gen_explicit')
-    print(v.value, v_ref)
     assert np.allclose(v.value, v_ref)
     assert np.allclose(beta.value, beta_ref)
     assert np.allclose(constr[0].dual_value, dual_ref)


### PR DESCRIPTION
One can represent a constraint of the form $$\lVert x \rVert_\infty \leq b$$ where $$x \in \mathbf{R}^n$$ in various equivalent ways.

For example, `-b <= x, x <= b`, `cp.abs(x) <= b`, and `cp.norm(x, 'inf') <= b` are all equivalent.

However, after canonicalization, they result in $$2n$$ inequalities in the first case, and in $$3n$$ inequalities in the other two cases. When generating explicit solvers, this is a significant difference, as the number of affine pieces in the piecewise affine solution grows exponentially with the number of inequality constraints.

Therefore, this PR introduces a simple pre-solve that keeps the number of inequalities small after canonicalization.